### PR TITLE
Fixed spelling error in localization doc

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -9,7 +9,7 @@ Godot has two ways to handle multiple languages right now:
 The CSV file way of doing things is fine if you work alone, but once you have multiple people working on translations you will get lot's of merge conflicts.
 Gettext is more powerful and splits translations into seperate files, but i don't like the format.
 
-However, you can add translations in code by using the TranslationServer. My localiation files are simple `.txt` files. This makes translating strings really easy. The file format is very straight forward: One translation per line; then a key followed by the translation (sperated by at least one whitespace). Here is an example for `English`:
+However, you can add translations in code by using the TranslationServer. My localization files are simple `.txt` files. This makes translating strings really easy. The file format is very straight forward: One translation per line; then a key followed by the translation (sperated by at least one whitespace). Here is an example for `English`:
 
 `en.txt`:
 


### PR DESCRIPTION
Changed 'localiation' to 'localization'