### PR TITLE
Changed style for PanelContainer and CheckButton

### DIFF
--- a/lorien/Main.tscn
+++ b/lorien/Main.tscn
@@ -13,7 +13,7 @@
 [ext_resource path="res://UI/Dialogs/ExitDialog.tscn" type="PackedScene" id=11]
 
 [sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 0.207843, 0.211765, 0.227451, 1 )
+bg_color = Color( 0.12549, 0.129412, 0.141176, 1 )
 border_width_left = 4
 border_width_top = 4
 border_width_right = 4
@@ -71,10 +71,10 @@ __meta__ = {
 }
 
 [node name="ColorPicker" type="ColorPicker" parent="BrushColorPickerPopup/PanelContainer"]
-margin_left = 16.0
-margin_top = 16.0
-margin_right = 321.0
-margin_bottom = 450.0
+margin_left = 8.0
+margin_top = 8.0
+margin_right = 317.0
+margin_bottom = 442.0
 edit_alpha = false
 __meta__ = {
 "_edit_use_anchors_": false
@@ -103,10 +103,10 @@ __meta__ = {
 }
 
 [node name="ColorPicker" type="ColorPicker" parent="BackgroundColorPickerPopup/PanelContainer"]
-margin_left = 16.0
-margin_top = 16.0
-margin_right = 326.001
-margin_bottom = 450.0
+margin_left = 4.0
+margin_top = 4.0
+margin_right = 314.001
+margin_bottom = 438.0
 edit_alpha = false
 __meta__ = {
 "_edit_use_anchors_": false
@@ -130,8 +130,8 @@ margin_bottom = 216.5
 theme = ExtResource( 8 )
 access = 2
 filters = PoolStringArray( "*.lorien" )
-current_dir = "/Users/mbrla/Projects/lorien/lorien"
-current_path = "/Users/mbrla/Projects/lorien/lorien/"
+current_dir = "/home/jere/GitHub/Lorien/lorien"
+current_path = "/home/jere/GitHub/Lorien/lorien/"
 __meta__ = {
 "_edit_lock_": true
 }
@@ -157,8 +157,8 @@ margin_right = 385.0
 margin_bottom = 216.5
 theme = ExtResource( 8 )
 access = 2
-current_dir = "/Users/mbrla/Projects/lorien/lorien"
-current_path = "/Users/mbrla/Projects/lorien/lorien/"
+current_dir = "/home/jere/GitHub/Lorien/lorien"
+current_path = "/home/jere/GitHub/Lorien/lorien/"
 
 [node name="UnsavedChangesDialog" parent="." instance=ExtResource( 7 )]
 visible = false

--- a/lorien/UI/Themes/theme_dark.tres
+++ b/lorien/UI/Themes/theme_dark.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=28 format=2]
+[gd_resource type="Theme" load_steps=29 format=2]
 
 [ext_resource path="res://Assets/Fonts/font_13.tres" type="DynamicFont" id=1]
 [ext_resource path="res://Assets/Fonts/font_14b.tres" type="DynamicFont" id=2]
@@ -32,6 +32,8 @@ content_margin_right = 6.0
 content_margin_top = 4.0
 content_margin_bottom = 4.0
 bg_color = Color( 0.12549, 0.129412, 0.141176, 1 )
+
+[sub_resource type="StyleBoxEmpty" id=22]
 
 [sub_resource type="StyleBoxLine" id=4]
 color = Color( 0.2821, 0.28768, 0.31, 1 )
@@ -165,6 +167,24 @@ Button/styles/focus = SubResource( 2 )
 Button/styles/hover = SubResource( 2 )
 Button/styles/normal = SubResource( 3 )
 Button/styles/pressed = SubResource( 3 )
+CheckButton/colors/font_color = Color( 0.88, 0.88, 0.88, 1 )
+CheckButton/colors/font_color_disabled = Color( 0.9, 0.9, 0.9, 0.2 )
+CheckButton/colors/font_color_hover = Color( 0.94, 0.94, 0.94, 1 )
+CheckButton/colors/font_color_hover_pressed = Color( 1, 1, 1, 1 )
+CheckButton/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+CheckButton/constants/check_vadjust = 0
+CheckButton/constants/hseparation = 4
+CheckButton/fonts/font = null
+CheckButton/icons/off = null
+CheckButton/icons/off_disabled = null
+CheckButton/icons/on = null
+CheckButton/icons/on_disabled = null
+CheckButton/styles/disabled = SubResource( 22 )
+CheckButton/styles/focus = null
+CheckButton/styles/hover = null
+CheckButton/styles/hover_pressed = null
+CheckButton/styles/normal = null
+CheckButton/styles/pressed = null
 ColorPicker/constants/h_width = 30
 ColorPicker/constants/label_width = 10
 ColorPicker/constants/margin = 4
@@ -266,7 +286,7 @@ Tree/colors/drop_position_color = Color( 1, 0.3, 0.2, 1 )
 Tree/colors/font_color = Color( 1, 1, 1, 1 )
 Tree/colors/font_color_selected = Color( 1, 1, 1, 1 )
 Tree/colors/guide_color = Color( 0, 0, 0, 0.1 )
-Tree/colors/relationship_line_color = Color( 0.27, 0.27, 0.27, 1 )
+Tree/colors/relationship_line_color = Color( 0.270588, 0.270588, 0.270588, 1 )
 Tree/colors/title_button_color = Color( 0.88, 0.88, 0.88, 1 )
 Tree/constants/button_margin = 4
 Tree/constants/draw_guides = 1


### PR DESCRIPTION
## Went from this:
![Screenshot_20210604_193225](https://user-images.githubusercontent.com/8162008/120869309-8b59f380-c56c-11eb-8406-875c53aee578.png)
![Screenshot_20210604_193237](https://user-images.githubusercontent.com/8162008/120869314-901ea780-c56c-11eb-8244-becb4ebe281c.png)
## To this:
![Screenshot_20210604_192620](https://user-images.githubusercontent.com/8162008/120869347-a62c6800-c56c-11eb-9ffa-5e61d51966b6.png)
![Screenshot_20210604_192648](https://user-images.githubusercontent.com/8162008/120869362-ad537600-c56c-11eb-9e3c-653519bfadf3.png)

Idk about those margin and current_dir/current_path changes, they happen every time I open the project and I've been discarding them from other commits, but now I actually edited Main.tscn. If it's problematic those lines can be restored to their original values.

Btw, why do those PanelContainers have their own style instead of getting it from the theme? That would totally be problematic for light theme and others.