### PR TITLE
Fixing Crash from Issue #35

### DIFF
--- a/lorien/InfiniteCanvas/InfiniteCanvas.gd
+++ b/lorien/InfiniteCanvas/InfiniteCanvas.gd
@@ -284,5 +284,9 @@ func _undo_delete_stroke(stroke: BrushStroke) -> void:
 	info.stroke_count += 1
 
 # -------------------------------------------------------------------------------------------------
+# I don't get why we are resizing the canvas to the size of the canvas
+# But capping the res at 4 or more pixels fixes the crash
+# See issue https://github.com/mbrlabs/Lorien/issues/35
 func _on_window_resized() -> void:
-	_viewport.size = get_viewport_rect().size
+	if get_viewport_rect().size.y >= 4:
+		_viewport.size = get_viewport_rect().size

--- a/lorien/InfiniteCanvas/InfiniteCanvas.gd
+++ b/lorien/InfiniteCanvas/InfiniteCanvas.gd
@@ -284,9 +284,5 @@ func _undo_delete_stroke(stroke: BrushStroke) -> void:
 	info.stroke_count += 1
 
 # -------------------------------------------------------------------------------------------------
-# I don't get why we are resizing the canvas to the size of the canvas
-# But capping the res at 4 or more pixels fixes the crash
-# See issue https://github.com/mbrlabs/Lorien/issues/35
 func _on_window_resized() -> void:
-	if get_viewport_rect().size.y >= 4:
-		_viewport.size = get_viewport_rect().size
+	_viewport.size = get_viewport_rect().size

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -19,6 +19,7 @@ onready var _background_color_picker: ColorPicker = $BackgroundColorPickerPopup/
 func _ready():
 	# Init stuff
 	OS.set_window_title("Lorien v%s" % Config.VERSION_STRING)
+	OS.min_window_size = Vector2(1920, 1080)*0.4
 	get_tree().set_auto_accept_quit(false)
 	_canvas.set_background_color(Config.DEFAULT_CANVAS_COLOR)
 	var docs_folder = OS.get_system_dir(OS.SYSTEM_DIR_DOCUMENTS)


### PR DESCRIPTION
This should fix the crash from issue #35

For some reason, Lorien Crashes when the viewport object becomes smaller than 4 pixels. This check for that and prevents the change.