### PR TITLE
Cleanup translations

### DIFF
--- a/lorien/Assets/I18n/de.txt
+++ b/lorien/Assets/I18n/de.txt
@@ -47,28 +47,23 @@ STATUSBAR_SELECTED_STROKES      Ausgewählte Striche
 # Settings
 # -----------------------------------------------------------------------------
 
-SETTINGS_TITLE              Einstellungen
-SETTINGS_GENERAL            Generell
-SETTINGS_APPEARANCE         Ansicht
-SETTINGS_RENDERING          Rendering
-SETTINGS_BRUSH_SIZE         Default Pinsel Größe
-SETTINGS_BRUSH_COLOR        Default Pinsel Farbe
-SETTINGS_CANVAS_COLOR       Default Canvas Farbe
-SETTINGS_PROJECT_FOLDER     Default Project Ordner
-SETTINGS_LANGUAGE           Sprache
-SETTINGS_THEME              Theme
-SETTINGS_AA_METHOD          Anti Aliasing Methode
-SETTINGS_AA_METHOD_NONE     Keine
-TARGET_FPS_FOREGROUND       Vordergrund Fps
-TARGET_FPS_BACKGROUND       Hintergrund Fps
-SETTINGS_BRUSH_ROUNDING	    Pinsel Abrundung
-
-# -----------------------------------------------------------------------------
-# Selection option strings
-# -----------------------------------------------------------------------------
-
-SETTINGS_BRUSH_ROUNDING_FLAT    Flach
-SETTINGS_BRUSH_ROUNDING_ROUND   Abgerundet
+SETTINGS_TITLE                  Einstellungen
+SETTINGS_GENERAL                Generell
+SETTINGS_APPEARANCE             Ansicht
+SETTINGS_RENDERING              Rendering
+SETTINGS_BRUSH_SIZE             Default Pinsel Größe
+SETTINGS_BRUSH_COLOR            Default Pinsel Farbe
+SETTINGS_CANVAS_COLOR           Default Canvas Farbe
+SETTINGS_PROJECT_FOLDER         Default Project Ordner
+SETTINGS_LANGUAGE               Sprache
+SETTINGS_THEME                  Theme
+SETTINGS_AA_METHOD              Anti Aliasing Methode
+SETTINGS_AA_METHOD_NONE         Keine
+SETTINGS_FPS_FOREGROUND         Vordergrund Fps
+SETTINGS_FPS_BACKGROUND         Hintergrund Fps
+SETTINGS_BRUSH_CAPS	            Pinsel Abrundung
+SETTINGS_BRUSH_CAPS_FLAT        Flach
+SETTINGS_BRUSH_CAPS_ROUND       Abgerundet
 
 # -----------------------------------------------------------------------------
 # About dialog

--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -47,28 +47,23 @@ STATUSBAR_SELECTED_STROKES      Selected strokes
 # Settings strings
 # -----------------------------------------------------------------------------
 
-SETTINGS_TITLE              Settings
-SETTINGS_GENERAL            General
-SETTINGS_APPEARANCE         Appearance
-SETTINGS_RENDERING          Rendering
-SETTINGS_BRUSH_SIZE         Default Brush Size
-SETTINGS_BRUSH_COLOR        Default Brush Color
-SETTINGS_CANVAS_COLOR       Default Canvas Color
-SETTINGS_PROJECT_FOLDER     Default Project Folder
-SETTINGS_LANGUAGE           Language
-SETTINGS_THEME              Theme
-SETTINGS_AA_METHOD          Anti Aliasing Method
-SETTINGS_AA_METHOD_NONE     None
-TARGET_FPS_FOREGROUND       Foreground Fps
-TARGET_FPS_BACKGROUND       Background Fps
-SETTINGS_BRUSH_ROUNDING     Brush Rounding Mode
-
-# -----------------------------------------------------------------------------
-# Selection option strings
-# -----------------------------------------------------------------------------
-
-SETTINGS_BRUSH_ROUNDING_FLAT    Flat
-SETTINGS_BRUSH_ROUNDING_ROUND   Round
+SETTINGS_TITLE                  Settings
+SETTINGS_GENERAL                General
+SETTINGS_APPEARANCE             Appearance
+SETTINGS_RENDERING              Rendering
+SETTINGS_BRUSH_SIZE             Default Brush Size
+SETTINGS_BRUSH_COLOR            Default Brush Color
+SETTINGS_CANVAS_COLOR           Default Canvas Color
+SETTINGS_PROJECT_FOLDER         Default Project Folder
+SETTINGS_LANGUAGE               Language
+SETTINGS_THEME                  Theme
+SETTINGS_AA_METHOD              Anti Aliasing Method
+SETTINGS_AA_METHOD_NONE         None
+SETTINGS_FPS_FOREGROUND         Foreground Fps
+SETTINGS_FPS_BACKGROUND         Background Fps
+SETTINGS_BRUSH_CAPS             Brush Rounding Mode
+SETTINGS_BRUSH_CAPS_FLAT        Flat
+SETTINGS_BRUSH_CAPS_ROUND       Round
 
 # -----------------------------------------------------------------------------
 # About dialog strings

--- a/lorien/Assets/I18n/es.txt
+++ b/lorien/Assets/I18n/es.txt
@@ -50,18 +50,23 @@ STATUSBAR_SELECTED_STROKES      Curvas seleccionadas
 # Settings strings
 # -----------------------------------------------------------------------------
 
-SETTINGS_TITLE              Configuración
-SETTINGS_GENERAL            General
-SETTINGS_APPEARANCE         Apariencia
-SETTINGS_RENDERING          Renderizado
-SETTINGS_BRUSH_SIZE         Tamaño de Pincel Predeterminado
-SETTINGS_BRUSH_COLOR        Color de Pincel Predeterminado
-SETTINGS_CANVAS_COLOR       Color de Canvas Predeterminado
-SETTINGS_PROJECT_FOLDER     Carpeta de Proyectos Predeterminada
-SETTINGS_LANGUAGE           Idioma
-SETTINGS_THEME              Tema
-SETTINGS_AA_METHOD          Método de Anti Aliasing
-SETTINGS_AA_METHOD_NONE     Ninguno
+SETTINGS_TITLE                  Configuración
+SETTINGS_GENERAL                General
+SETTINGS_APPEARANCE             Apariencia
+SETTINGS_RENDERING              Renderizado
+SETTINGS_BRUSH_SIZE             Tamaño de Pincel Predeterminado
+SETTINGS_BRUSH_COLOR            Color de Pincel Predeterminado
+SETTINGS_CANVAS_COLOR           Color de Canvas Predeterminado
+SETTINGS_PROJECT_FOLDER         Carpeta de Proyectos Predeterminada
+SETTINGS_LANGUAGE               Idioma
+SETTINGS_THEME                  Tema
+SETTINGS_AA_METHOD              Método de Anti Aliasing
+SETTINGS_AA_METHOD_NONE         Ninguno
+SETTINGS_FPS_FOREGROUND         Foreground Fps # TODO
+SETTINGS_FPS_BACKGROUND         Background Fps # TODO
+SETTINGS_BRUSH_CAPS             Brush Rounding Mode # TODO
+SETTINGS_BRUSH_CAPS_FLAT        Flat # TODO
+SETTINGS_BRUSH_CAPS_ROUND       Round # TODO
 
 # -----------------------------------------------------------------------------
 # About dialog strings

--- a/lorien/Assets/I18n/it.txt
+++ b/lorien/Assets/I18n/it.txt
@@ -47,18 +47,23 @@ STATUSBAR_SELECTED_STROKES      Tratti selezionati
 # Settings strings
 # -----------------------------------------------------------------------------
 
-SETTINGS_TITLE              Impostazioni
-SETTINGS_GENERAL            Generale
-SETTINGS_APPEARANCE         Aspetto
-SETTINGS_RENDERING          Rendering
-SETTINGS_BRUSH_SIZE         Dimensione Pennello Predefinita
-SETTINGS_BRUSH_COLOR        Colore Pennello Predefinito
-SETTINGS_CANVAS_COLOR       Colore Tela Predefinito
-SETTINGS_PROJECT_FOLDER     Cartella di Progetto Predefinita
-SETTINGS_LANGUAGE           Lingua
-SETTINGS_THEME              Tema
-SETTINGS_AA_METHOD          Metodo Anti-Aliasing
-SETTINGS_AA_METHOD_NONE     Nessuno
+SETTINGS_TITLE                  Impostazioni
+SETTINGS_GENERAL                Generale
+SETTINGS_APPEARANCE             Aspetto
+SETTINGS_RENDERING              Rendering
+SETTINGS_BRUSH_SIZE             Dimensione Pennello Predefinita
+SETTINGS_BRUSH_COLOR            Colore Pennello Predefinito
+SETTINGS_CANVAS_COLOR           Colore Tela Predefinito
+SETTINGS_PROJECT_FOLDER         Cartella di Progetto Predefinita
+SETTINGS_LANGUAGE               Lingua
+SETTINGS_THEME                  Tema
+SETTINGS_AA_METHOD              Metodo Anti-Aliasing
+SETTINGS_AA_METHOD_NONE         Nessuno
+SETTINGS_FPS_FOREGROUND         Foreground Fps # TODO
+SETTINGS_FPS_BACKGROUND         Background Fps # TODO
+SETTINGS_BRUSH_CAPS             Brush Rounding Mode # TODO
+SETTINGS_BRUSH_CAPS_FLAT        Flat # TODO
+SETTINGS_BRUSH_CAPS_ROUND       Round # TODO
 
 # -----------------------------------------------------------------------------
 # About dialog strings

--- a/lorien/Assets/I18n/ru.txt
+++ b/lorien/Assets/I18n/ru.txt
@@ -47,18 +47,23 @@ STATUSBAR_SELECTED_STROKES      Выбранные штрихи
 # Settings strings
 # -----------------------------------------------------------------------------
 
-SETTINGS_TITLE              Настройки
-SETTINGS_GENERAL            Общее
-SETTINGS_APPEARANCE         Внешний вид
-SETTINGS_RENDERING          Рендеринг
-SETTINGS_BRUSH_SIZE         Размер кисти по умолчанию
-SETTINGS_BRUSH_COLOR        Цвет кисти по умолчанию
-SETTINGS_CANVAS_COLOR       Цвет холста по умолчанию
-SETTINGS_PROJECT_FOLDER     Папка проекта по умолчанию
-SETTINGS_LANGUAGE           Язык
-SETTINGS_THEME              Тема
-SETTINGS_AA_METHOD          Метод сглаживания
-SETTINGS_AA_METHOD_NONE     Не использовать
+SETTINGS_TITLE                  Настройки
+SETTINGS_GENERAL                Общее
+SETTINGS_APPEARANCE             Внешний вид
+SETTINGS_RENDERING              Рендеринг
+SETTINGS_BRUSH_SIZE             Размер кисти по умолчанию
+SETTINGS_BRUSH_COLOR            Цвет кисти по умолчанию
+SETTINGS_CANVAS_COLOR           Цвет холста по умолчанию
+SETTINGS_PROJECT_FOLDER         Папка проекта по умолчанию
+SETTINGS_LANGUAGE               Язык
+SETTINGS_THEME                  Тема
+SETTINGS_AA_METHOD              Метод сглаживания
+SETTINGS_AA_METHOD_NONE         Не использовать
+SETTINGS_FPS_FOREGROUND         Foreground Fps # TODO
+SETTINGS_FPS_BACKGROUND         Background Fps # TODO
+SETTINGS_BRUSH_CAPS             Brush Rounding Mode # TODO
+SETTINGS_BRUSH_CAPS_FLAT        Flat # TODO
+SETTINGS_BRUSH_CAPS_ROUND       Round # TODO
 
 # -----------------------------------------------------------------------------
 # About dialog strings

--- a/lorien/UI/Dialogs/SettingsDialog.tscn
+++ b/lorien/UI/Dialogs/SettingsDialog.tscn
@@ -8,7 +8,6 @@
 [sub_resource type="StyleBoxEmpty" id=2]
 
 [node name="SettingsDialog" type="WindowDialog"]
-visible = true
 margin_right = 400.0
 margin_bottom = 250.0
 rect_min_size = Vector2( 520, 350 )
@@ -208,28 +207,28 @@ __meta__ = {
 }
 
 [node name="HSeparator3" type="HSeparator" parent="MarginContainer/TabContainer/Appearance/VBoxContainer"]
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 12.0
 custom_styles/separator = SubResource( 1 )
 custom_constants/separation = 12
 
 [node name="Theme" type="HBoxContainer" parent="MarginContainer/TabContainer/Appearance/VBoxContainer"]
 margin_top = 16.0
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 41.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="MarginContainer/TabContainer/Appearance/VBoxContainer/Theme"]
 margin_top = 4.0
-margin_right = 236.0
+margin_right = 246.0
 margin_bottom = 21.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
 text = "SETTINGS_THEME"
 
 [node name="Theme" type="OptionButton" parent="MarginContainer/TabContainer/Appearance/VBoxContainer/Theme"]
-margin_left = 240.0
-margin_right = 476.0
+margin_left = 250.0
+margin_right = 496.0
 margin_bottom = 25.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -239,7 +238,7 @@ selected = 0
 
 [node name="HSeparator5" type="HSeparator" parent="MarginContainer/TabContainer/Appearance/VBoxContainer"]
 margin_top = 45.0
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 57.0
 custom_styles/separator = SubResource( 1 )
 custom_constants/separation = 12
@@ -267,28 +266,28 @@ __meta__ = {
 }
 
 [node name="HSeparator3" type="HSeparator" parent="MarginContainer/TabContainer/Rendering/VBoxContainer"]
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 12.0
 custom_styles/separator = SubResource( 1 )
 custom_constants/separation = 12
 
 [node name="AntiAliasing" type="HBoxContainer" parent="MarginContainer/TabContainer/Rendering/VBoxContainer"]
 margin_top = 16.0
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 41.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/AntiAliasing"]
 margin_top = 4.0
-margin_right = 236.0
+margin_right = 246.0
 margin_bottom = 21.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
 text = "SETTINGS_AA_METHOD"
 
 [node name="AntiAliasing" type="OptionButton" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/AntiAliasing"]
-margin_left = 240.0
-margin_right = 476.0
+margin_left = 250.0
+margin_right = 496.0
 margin_bottom = 25.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -298,44 +297,44 @@ selected = 0
 
 [node name="BrushRounding" type="HBoxContainer" parent="MarginContainer/TabContainer/Rendering/VBoxContainer"]
 margin_top = 45.0
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 70.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/BrushRounding"]
 margin_top = 4.0
-margin_right = 219.0
+margin_right = 246.0
 margin_bottom = 21.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
-text = "SETTINGS_BRUSH_ROUNDING"
+text = "SETTINGS_BRUSH_CAPS"
 
 [node name="OptionButton" type="OptionButton" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/BrushRounding"]
-margin_left = 223.0
-margin_right = 476.0
+margin_left = 250.0
+margin_right = 496.0
 margin_bottom = 25.0
 size_flags_horizontal = 3
-text = "SETTINGS_BRUSH_ROUNDING_FLAT"
-items = [ "SETTINGS_BRUSH_ROUNDING_FLAT", null, false, 0, null, "SETTINGS_BRUSH_ROUNDING_ROUND", null, false, 1, null ]
+text = "SETTINGS_BRUSH_CAPS_FLAT"
+items = [ "SETTINGS_BRUSH_CAPS_FLAT", null, false, 0, null, "SETTINGS_BRUSH_CAPS_ROUND", null, false, 1, null ]
 selected = 0
 
 [node name="TargetFramerate" type="HBoxContainer" parent="MarginContainer/TabContainer/Rendering/VBoxContainer"]
 margin_top = 74.0
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 95.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/TargetFramerate"]
 margin_top = 2.0
-margin_right = 236.0
+margin_right = 246.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
-text = "TARGET_FPS_FOREGROUND"
+text = "SETTINGS_FPS_FOREGROUND"
 
 [node name="TargetFramerate" type="SpinBox" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/TargetFramerate"]
-margin_left = 240.0
-margin_right = 476.0
+margin_left = 250.0
+margin_right = 496.0
 margin_bottom = 21.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -346,21 +345,21 @@ allow_greater = true
 
 [node name="BackgroundFramerate" type="HBoxContainer" parent="MarginContainer/TabContainer/Rendering/VBoxContainer"]
 margin_top = 99.0
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 120.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/BackgroundFramerate"]
 margin_top = 2.0
-margin_right = 236.0
+margin_right = 246.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
-text = "TARGET_FPS_BACKGROUND"
+text = "SETTINGS_FPS_BACKGROUND"
 
 [node name="BackgroundFramerate" type="SpinBox" parent="MarginContainer/TabContainer/Rendering/VBoxContainer/BackgroundFramerate"]
-margin_left = 240.0
-margin_right = 476.0
+margin_left = 250.0
+margin_right = 496.0
 margin_bottom = 21.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -371,7 +370,7 @@ allow_greater = true
 
 [node name="HSeparator4" type="HSeparator" parent="MarginContainer/TabContainer/Rendering/VBoxContainer"]
 margin_top = 124.0
-margin_right = 476.0
+margin_right = 496.0
 margin_bottom = 136.0
 custom_styles/separator = SubResource( 1 )
 custom_constants/separation = 12


### PR DESCRIPTION
I wanted to add a new setting to the settings dialog and noticed that some translation keys were named inconsistently. I also found some missing ones (except German and English), so i added them to the other translations in English with a TODO comment. It's probably easier to keep track what still lacks translations when we do it like that. 