### PR TITLE
use low processor mode

### DIFF
--- a/lorien/project.godot
+++ b/lorien/project.godot
@@ -196,6 +196,7 @@ _global_script_class_icons={
 
 config/name="Lorien"
 run/main_scene="res://Main.tscn"
+run/low_processor_mode=true
 boot_splash/image="res://Assets/Textures/boot.png"
 boot_splash/fullsize=false
 boot_splash/use_filter=false


### PR DESCRIPTION
the Godot docs say
> When creating a non-game application, make sure to enable low-processor mode in the Project Settings to decrease CPU and GPU usage.
source: https://docs.godotengine.org/en/stable/about/faq.html#is-it-possible-to-use-godot-to-create-non-game-applications

which links to here: https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-property-application-run-low-processor-mode
> bool application/run/low_processor_mode
> If true, enables low-processor usage mode. This setting only works on desktop platforms. The screen is not redrawn if nothing changes visually. This is meant for writing applications and editors, but is pretty useless (and can hurt performance) in most games.

I am not familiar with your app so I don't want to presume this would just work, but I'm curious whether you're aware of and have tried this setting.