### PR TITLE
Background color picker bug

### DIFF
--- a/lorien/Main.tscn
+++ b/lorien/Main.tscn
@@ -85,8 +85,10 @@ __meta__ = {
 }
 
 [node name="ColorPicker" type="ColorPicker" parent="BackgroundColorPickerPopup/PanelContainer"]
-margin_right = 309.0
-margin_bottom = 404.0
+margin_left = 4.0
+margin_top = 4.0
+margin_right = 313.0
+margin_bottom = 408.0
 edit_alpha = false
 presets_enabled = false
 presets_visible = false

--- a/lorien/Main.tscn
+++ b/lorien/Main.tscn
@@ -85,10 +85,8 @@ __meta__ = {
 }
 
 [node name="ColorPicker" type="ColorPicker" parent="BackgroundColorPickerPopup/PanelContainer"]
-margin_left = 4.0
-margin_top = 4.0
-margin_right = 313.0
-margin_bottom = 408.0
+margin_right = 309.0
+margin_bottom = 404.0
 edit_alpha = false
 presets_enabled = false
 presets_visible = false

--- a/lorien/UI/Toolbar.gd
+++ b/lorien/UI/Toolbar.gd
@@ -152,8 +152,11 @@ func _on_SelectToolButton_pressed():
 # -------------------------------------------------------------------------------------------------
 func _on_BackgroundColorButton_pressed():
 	_background_color_picker_popup.popup()
-	_background_color_picker_popup.rect_position.y = rect_size.y * 2 # Assumes Menubar and Toolbar have the same height
+	
+	# Stop popup from automatically adjusting position, Assumes Menubar and Toolbar have the same height
+	_background_color_picker_popup.rect_position.y = rect_size.y * 2
 
+# Workaround for a bug in godot: https://github.com/godotengine/godot/issues/38171
 # -------------------------------------------------------------------------------------------------
 func _on_window_resized() -> void:
 	if _background_color_picker_popup.visible:

--- a/lorien/UI/Toolbar.gd
+++ b/lorien/UI/Toolbar.gd
@@ -46,6 +46,7 @@ var _last_active_tool_button: TextureButton
 # -------------------------------------------------------------------------------------------------
 func _ready():
 	var brush_size: int = Settings.get_value(Settings.GENERAL_DEFAULT_BRUSH_SIZE, Config.DEFAULT_BRUSH_SIZE)
+	get_tree().get_root().connect("size_changed", self, "_on_window_resized")
 	_background_color_picker.connect("color_changed", self, "_on_background_color_changed")
 	_brush_size_label.text = str(brush_size)
 	_brush_size_slider.value = brush_size
@@ -151,6 +152,12 @@ func _on_SelectToolButton_pressed():
 # -------------------------------------------------------------------------------------------------
 func _on_BackgroundColorButton_pressed():
 	_background_color_picker_popup.popup()
+	_background_color_picker_popup.rect_position.y = rect_size.y * 2 # Assumes Menubar and Toolbar have the same height
+
+# -------------------------------------------------------------------------------------------------
+func _on_window_resized() -> void:
+	if _background_color_picker_popup.visible:
+		_background_color_picker_popup.rect_position.x = rect_size.x - _background_color_picker_popup.rect_size.x
 
 # -------------------------------------------------------------------------------------------------
 func _on_GridButton_toggled(toggled: bool):


### PR DESCRIPTION
fixes issue #99

It seems this is bug is caused the popup nodes functionality, See line 148 https://github.com/godotengine/godot/blob/master/scene/gui/popup.cpp

So an alternative would be to use a different type of node and handle the closing input events like the palette button

In this implementation I could group the Menubar and Toolbar into a VBox and then use the size.y of the VBox instead of the assumption at line 155

line 158-160 makes the background color picker move with the window when its resized. Which is a workaround for a bug in godot https://github.com/godotengine/godot/issues/38171 