### PR TITLE
Add style to dark theme to make FileDialog's file tree visible 

### DIFF
--- a/lorien/UI/Themes/theme_dark.tres
+++ b/lorien/UI/Themes/theme_dark.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=29 format=2]
+[gd_resource type="Theme" load_steps=30 format=2]
 
 [ext_resource path="res://Assets/Fonts/font_big_bold.tres" type="DynamicFont" id=1]
 [ext_resource path="res://Assets/Fonts/font_normal.tres" type="DynamicFont" id=2]
@@ -155,6 +155,12 @@ shadow_size = 4
 
 [sub_resource type="StyleBoxFlat" id=21]
 bg_color = Color( 0.12549, 0.129412, 0.141176, 1 )
+
+[sub_resource type="StyleBoxFlat" id=24]
+draw_center = false
+border_width_bottom = 12
+border_color = Color( 0.145098, 0.145098, 0.164706, 1 )
+border_blend = true
 
 [sub_resource type="StyleBoxFlat" id=22]
 content_margin_left = 4.0
@@ -346,7 +352,7 @@ Tree/icons/select_arrow = null
 Tree/icons/unchecked = null
 Tree/icons/updown = null
 Tree/styles/bg = SubResource( 21 )
-Tree/styles/bg_focus = SubResource( 21 )
+Tree/styles/bg_focus = SubResource( 24 )
 Tree/styles/button_pressed = null
 Tree/styles/cursor = null
 Tree/styles/cursor_unfocused = null


### PR DESCRIPTION
Fixes #104

Adds a new style to the theme to stop from covering FileDialog's file tree when in focus.

This solution adds a blended border at the bottom of the file tree when its in focus, an alternative would be to get rid of the style entirely.