### PR TITLE
Load textures into hscrollbar theme

### DIFF
--- a/lorien/UI/Themes/theme_dark.tres
+++ b/lorien/UI/Themes/theme_dark.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=35 format=2]
+[gd_resource type="Theme" load_steps=38 format=2]
 
 [ext_resource path="res://Assets/Fonts/font_big_bold.tres" type="DynamicFont" id=1]
 [ext_resource path="res://Assets/Fonts/font_normal.tres" type="DynamicFont" id=2]
@@ -6,6 +6,9 @@
 [ext_resource path="res://Assets/Icons/close.png" type="Texture" id=4]
 [ext_resource path="res://Assets/Textures/switch_off.png" type="Texture" id=5]
 [ext_resource path="res://Assets/Textures/switch_on.png" type="Texture" id=6]
+[ext_resource path="res://Assets/Textures/scrollbar_hl.png" type="Texture" id=7]
+[ext_resource path="res://Assets/Textures/scrollbar.png" type="Texture" id=8]
+[ext_resource path="res://Assets/Textures/scrollbar_bg.png" type="Texture" id=9]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 6.0
@@ -47,6 +50,7 @@ corner_radius_bottom_right = 1
 corner_radius_bottom_left = 1
 
 [sub_resource type="StyleBoxTexture" id=26]
+texture = ExtResource( 8 )
 region_rect = Rect2( 0, 0, 12, 12 )
 margin_left = 6.0
 margin_right = 6.0
@@ -54,6 +58,7 @@ expand_margin_left = 2.0
 expand_margin_right = 2.0
 
 [sub_resource type="StyleBoxTexture" id=28]
+texture = ExtResource( 7 )
 region_rect = Rect2( 0, 0, 12, 12 )
 margin_left = 6.0
 margin_right = 6.0
@@ -61,6 +66,7 @@ expand_margin_left = 2.0
 expand_margin_right = 2.0
 
 [sub_resource type="StyleBoxTexture" id=29]
+texture = ExtResource( 9 )
 region_rect = Rect2( 0, 0, 12, 12 )
 margin_left = 4.0
 margin_right = 4.0


### PR DESCRIPTION
Other textures were reconnected to the theme in commit 65bc8f4e9a1f3199a84c5e0bcee8d9743dcb081c

Assuming these weren't going to be updated or removed, I have loaded the textures needed for the toolbar's horizontal scrollbar.

arrow_right.png remains unconnected to the theme because it has no use right now (I think).