### PR TITLE
Improve Simplified Chinese translation

### DIFF
--- a/lorien/Assets/I18n/zh-CN.txt
+++ b/lorien/Assets/I18n/zh-CN.txt
@@ -87,7 +87,7 @@ ABOUT_DIALOG_TITLE              关于
 ABOUT_DIALOG_COPYRIGHT          © 2021-2022 Marcus Brummer & contributors 
 ABOUT_DIALOG_LICSENSE           Lorien 采用以下协议授权:
 ABOUT_DIALOG_BASED_ON           Lorien 基于：
-ABOUT_DIALOG_EASTEREGG          复活节彩蛋字符:
+ABOUT_DIALOG_EASTEREGG          复活节彩蛋角色:
 
 # -----------------------------------------------------------------------------
 # Unsaved changes dialog

--- a/lorien/Assets/I18n/zh-CN.txt
+++ b/lorien/Assets/I18n/zh-CN.txt
@@ -1,4 +1,4 @@
-LANGUAGE_NAME 简体中文
+LANGUAGE_NAME Simplified Chinese
 
 # -----------------------------------------------------------------------------
 # Menu strings


### PR DESCRIPTION
1. The font name of Simplified Chinese can' t be displayed properly in other languages, for example, when the language is set to English, it will be displayed as blank, so I changed it from "简体中文" to "Simplified Chinese". For your convenience, you can view the following screenshots.
![screenshot2](https://user-images.githubusercontent.com/20807713/173475603-6b3a0c8c-78aa-42c9-9539-a6b7e701acb9.png)
3. Improved the translation of Simplified Chinese.