### PR TITLE
primitive config with custom shortcuts

### DIFF
--- a/lorien/Misc/Settings.gd
+++ b/lorien/Misc/Settings.gd
@@ -25,6 +25,7 @@ var language_names: PoolStringArray
 func _ready():
 	_config_file = ConfigFile.new()
 	_load_settings()
+	_load_shortcuts()
 
 	var i18n := I18nParser.new()
 	var parse_result := i18n.load_files()
@@ -48,7 +49,7 @@ func _save_settings() -> int:
 	if err == ERR_FILE_NOT_FOUND:
 		pass
 	elif err != OK:
-		printerr("Failed to load settings file")
+		printerr("Failed to save settings file")
 	
 	return err
 
@@ -61,4 +62,60 @@ func set_value(key: String, value = null):
 	_config_file.set_value(DEFAULT_SECTION, key, value)
 	_save_settings()
 	
+# -------------------------------------------------------------------------------------------------
+func _set_default_shortcuts():	
+	for action_name in InputMap.get_actions():
+		for event in InputMap.get_action_list(action_name): 
+			if typeof(event) == TYPE_OBJECT && event.is_class("InputEventJoypadButton"):
+				continue
+			if _config_file.has_section_key("shortcuts", action_name):
+				continue
+			var shortcut = OS.get_scancode_string(event.get_scancode_with_modifiers())
+			_config_file.set_value("shortcuts", action_name, shortcut)
+			continue # for now every action can have only one shortcut
+			# parsing multiple shortcuts should be ease -  this is just a concept
+			
+	_save_settings()	
+
+# -------------------------------------------------------------------------------------------------
+func _load_shortcuts():	
+	if !_config_file.get_section_keys("shortcuts"):
+		print("Cannot find 'shortcuts' section in 'settings.cfg'. Creating default one.")
+		_set_default_shortcuts()
+		return
+	
+	for action_name in InputMap.get_actions():
+		for event in InputMap.get_action_list(action_name): 
+			if typeof(event) == TYPE_OBJECT && event.is_class("InputEventJoypadButton"):
+				continue
+			if !_config_file.has_section_key("shortcuts", action_name):
+				continue
+			var shortcut = _config_file.get_value("shortcuts", action_name)
+			
+			var key = shortcut.split("+", false)[-1]
+			# OS.find_scancode_from_string don't work with modifiier keys like control, meta etc.
+			var scancode = OS.find_scancode_from_string(key)
+			
+			if scancode == 0:
+				print("invalid key name '", key, "' in '", action_name, "' of shortcuts section")
+				continue
+			
+			event.control = false
+			event.meta = false
+			event.alt = false
+			event.shift = false
+			event.command = false
+			if "Control" in shortcut:
+				event.control = true
+			if "Meta" in shortcut:
+				event.meta = true
+			if "Alt" in shortcut:
+				event.alt = true
+			if "Shift" in shortcut:
+				event.shift = true
+			if "Command" in shortcut:
+				event.command = true
+			
+			event.scancode = scancode
+			continue
 


### PR DESCRIPTION
This is just a simple/primitive implementation of custom shortcuts. For now, editing shortcuts can be made only throw settings.cfg file.

There is problem with some combination of shortucts (like Control+[key] and Control+Shift+[key]), because godot don't check other shortcuts if overlap. I found [this](https://godotengine.org/qa/51236/input-map-using-multiple-keys-like-ctrl-up) about possible solution.


(I know almost nothing about godot so I am really sorry if I did something wrong.)