### PR TITLE
Maintain selected color when adding to palette

### DIFF
--- a/lorien/UI/Dialogs/EditPaletteDialog.gd
+++ b/lorien/UI/Dialogs/EditPaletteDialog.gd
@@ -82,7 +82,7 @@ func _on_NameLineEdit_text_changed(new_text: String) -> void:
 func _on_AddColorButton_pressed() -> void:
 	if _palette.colors.size() < Config.MAX_PALETTE_SIZE:
 		_palette_edited = true
-		var new_color := Color.white
+		var new_color := _palette.colors[_active_button_index]
 		
 		# Create a new color array with the new color
 		var arr := []


### PR DESCRIPTION
Not a major change; just uses the last selected color for the new color when creating a palette.


In most programs (even ms paint), when adding a color to a palette it doesn't reset the color to white. Instead, it keeps the selected color.

See GIF of changes:
![Gif of Palette Selector](https://user-images.githubusercontent.com/67179348/177198828-bb5a72b7-ccb6-48cc-9a4f-9e57a2f97edf.gif)
.