### PR TITLE
Canvas keybinding controls

### DIFF
--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -167,6 +167,10 @@ ACTION_toggle_player               EFF TWELVE
 ACTION_toggle_fullscreen           Toggle fullscreen
 ACTION_canvas_zoom_in              Zoom in
 ACTION_canvas_zoom_out             Zoom out
+ACTION_canvas_pan_up               Pan up
+ACTION_canvas_pan_down             Pan down
+ACTION_canvas_pan_right            Pan right
+ACTION_canvas_pan_left             Pan left
 
 # -----------------------------------------------------------------------------
 # Kebindings dialog messages

--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -165,6 +165,8 @@ ACTION_duplicate_strokes           Duplicate strokes
 ACTION_toggle_distraction_free_mode Toggle distraction free mode
 ACTION_toggle_player               EFF TWELVE
 ACTION_toggle_fullscreen           Toggle fullscreen
+ACTION_canvas_zoom_in              Zoom in
+ACTION_canvas_zoom_out             Zoom out
 
 # -----------------------------------------------------------------------------
 # Kebindings dialog messages

--- a/lorien/InfiniteCanvas/Cursor/BaseCursor.gd
+++ b/lorien/InfiniteCanvas/Cursor/BaseCursor.gd
@@ -5,9 +5,20 @@ extends Sprite
 var _brush_size: int
 var _pressure := 1.0
 
+onready var _camera: Camera2D = get_viewport().get_node("Camera2D")
+
 # -------------------------------------------------------------------------------------------------
 func _ready() -> void:
 	pass
+
+# -------------------------------------------------------------------------------------------------
+func _input(event):
+	if event is InputEventMouseMotion:
+		_update_position()
+
+# -------------------------------------------------------------------------------------------------
+func _update_position():
+	global_position = _camera.get_global_mouse_position()
 
 # -------------------------------------------------------------------------------------------------
 func set_pressure(pressure: float) -> void:
@@ -18,6 +29,9 @@ func change_size(value: int) -> void:
 	pass
 
 # -------------------------------------------------------------------------------------------------
+func _on_canvas_position_changed(pos: Vector2) -> void:
+	_update_position()
+
+# -------------------------------------------------------------------------------------------------
 func _on_zoom_changed(value: float) -> void:
 	pass
-

--- a/lorien/InfiniteCanvas/InfiniteCanvas.gd
+++ b/lorien/InfiniteCanvas/InfiniteCanvas.gd
@@ -40,7 +40,12 @@ func _ready():
 	_active_tool.enabled = false
 	
 	get_tree().get_root().connect("size_changed", self, "_on_window_resized")
-	_camera.connect("zoom_changed", $Viewport/SelectionCursor, "_on_zoom_changed")
+	
+	for child in $Viewport.get_children():
+		if child is BaseCursor:
+			_camera.connect("zoom_changed", child, "_on_zoom_changed")
+			_camera.connect("position_changed", child, "_on_canvas_position_changed")
+	
 	_camera.connect("zoom_changed", self, "_on_zoom_changed")
 	_camera.connect("position_changed", self, "_on_camera_moved")
 	_viewport.size = OS.window_size

--- a/lorien/InfiniteCanvas/PanZoomCamera.gd
+++ b/lorien/InfiniteCanvas/PanZoomCamera.gd
@@ -6,6 +6,7 @@ signal position_changed(value)
 const ZOOM_INCREMENT := 1.1 	# Feel free to modify (Krita uses sqrt(2))
 const MIN_ZOOM_LEVEL := 0.1
 const MAX_ZOOM_LEVEL := 100
+const KEYBOARD_PAN_CONSTANT := 20
 
 var _is_input_enabled := true
 
@@ -59,9 +60,27 @@ func tool_event(event: InputEvent) -> void:
 		
 		elif Utils.event_pressed_bug_workaround("canvas_zoom_in", event):
 			_do_zoom_scroll(-1)
+			get_tree().set_input_as_handled()
 		
 		elif Utils.event_pressed_bug_workaround("canvas_zoom_out", event):
 			_do_zoom_scroll(1)
+			get_tree().set_input_as_handled()
+		
+		elif Utils.event_pressed_bug_workaround("canvas_pan_left", event):
+			_do_pan(Vector2.LEFT * KEYBOARD_PAN_CONSTANT)
+			get_tree().set_input_as_handled()
+
+		elif Utils.event_pressed_bug_workaround("canvas_pan_right", event):
+			_do_pan(Vector2.RIGHT * KEYBOARD_PAN_CONSTANT)
+			get_tree().set_input_as_handled()
+
+		elif Utils.event_pressed_bug_workaround("canvas_pan_up", event):
+			_do_pan(Vector2.UP * KEYBOARD_PAN_CONSTANT)
+			get_tree().set_input_as_handled()
+
+		elif Utils.event_pressed_bug_workaround("canvas_pan_down", event):
+			_do_pan(Vector2.DOWN * KEYBOARD_PAN_CONSTANT)
+			get_tree().set_input_as_handled()
 
 # -------------------------------------------------------------------------------------------------
 func _do_pan(pan: Vector2) -> void:

--- a/lorien/InfiniteCanvas/PanZoomCamera.gd
+++ b/lorien/InfiniteCanvas/PanZoomCamera.gd
@@ -56,6 +56,12 @@ func tool_event(event: InputEvent) -> void:
 				_do_pan(event.relative)
 			elif _zoom_active:
 				_do_zoom_drag(event.relative.y)
+		
+		elif Utils.event_pressed_bug_workaround("canvas_zoom_in", event):
+			_do_zoom_scroll(-1)
+		
+		elif Utils.event_pressed_bug_workaround("canvas_zoom_out", event):
+			_do_zoom_scroll(1)
 
 # -------------------------------------------------------------------------------------------------
 func _do_pan(pan: Vector2) -> void:

--- a/lorien/InfiniteCanvas/PanZoomCamera.gd
+++ b/lorien/InfiniteCanvas/PanZoomCamera.gd
@@ -67,19 +67,19 @@ func tool_event(event: InputEvent) -> void:
 			get_tree().set_input_as_handled()
 		
 		elif Utils.event_pressed_bug_workaround("canvas_pan_left", event):
-			_do_pan(Vector2.LEFT * KEYBOARD_PAN_CONSTANT)
+			_do_pan(-Vector2.LEFT * KEYBOARD_PAN_CONSTANT)
 			get_tree().set_input_as_handled()
 
 		elif Utils.event_pressed_bug_workaround("canvas_pan_right", event):
-			_do_pan(Vector2.RIGHT * KEYBOARD_PAN_CONSTANT)
+			_do_pan(-Vector2.RIGHT * KEYBOARD_PAN_CONSTANT)
 			get_tree().set_input_as_handled()
 
 		elif Utils.event_pressed_bug_workaround("canvas_pan_up", event):
-			_do_pan(Vector2.UP * KEYBOARD_PAN_CONSTANT)
+			_do_pan(-Vector2.UP * KEYBOARD_PAN_CONSTANT)
 			get_tree().set_input_as_handled()
 
 		elif Utils.event_pressed_bug_workaround("canvas_pan_down", event):
-			_do_pan(Vector2.DOWN * KEYBOARD_PAN_CONSTANT)
+			_do_pan(-Vector2.DOWN * KEYBOARD_PAN_CONSTANT)
 			get_tree().set_input_as_handled()
 
 # -------------------------------------------------------------------------------------------------

--- a/lorien/InfiniteCanvas/Tools/BrushTool.gd
+++ b/lorien/InfiniteCanvas/Tools/BrushTool.gd
@@ -19,7 +19,6 @@ func tool_event(event: InputEvent) -> void:
 	_cursor.set_pressure(1.0)
 	
 	if event is InputEventMouseMotion:
-		_cursor.global_position = xform_vector2(event.global_position)
 		_current_position = event.position
 		_current_pressure = event.pressure
 		if performing_stroke:

--- a/lorien/InfiniteCanvas/Tools/CanvasTool.gd
+++ b/lorien/InfiniteCanvas/Tools/CanvasTool.gd
@@ -41,8 +41,6 @@ func set_enabled(e: bool) -> void:
 	set_process(enabled)
 	set_process_input(enabled)
 	_cursor.set_visible(enabled)
-	if enabled && _canvas:
-		_cursor.global_position = xform_vector2(get_viewport().get_mouse_position())
 
 # -------------------------------------------------------------------------------------------------
 func get_enabled() -> bool:

--- a/lorien/InfiniteCanvas/Tools/CircleTool.gd
+++ b/lorien/InfiniteCanvas/Tools/CircleTool.gd
@@ -28,7 +28,6 @@ func tool_event(event: InputEvent) -> void:
 	var should_draw_circle := Input.is_key_pressed(KEY_SHIFT)
 	
 	if event is InputEventMouseMotion:
-		_cursor.global_position = xform_vector2(event.global_position)
 		if performing_stroke:
 			_cursor.set_pressure(event.pressure)
 			remove_all_stroke_points()

--- a/lorien/InfiniteCanvas/Tools/EraserTool.gd
+++ b/lorien/InfiniteCanvas/Tools/EraserTool.gd
@@ -14,7 +14,6 @@ var _bounding_box_cache = {} # BrushStroke -> Rect2
 func tool_event(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		_last_mouse_position = xform_vector2(event.global_position)
-		_cursor.global_position = _last_mouse_position
 	if event is InputEventMouseButton:
 		if event.button_index == BUTTON_LEFT:
 			if event.pressed:

--- a/lorien/InfiniteCanvas/Tools/LineTool.gd
+++ b/lorien/InfiniteCanvas/Tools/LineTool.gd
@@ -21,7 +21,6 @@ func tool_event(event: InputEvent) -> void:
 	
 	# Moving the tail
 	elif event is InputEventMouseMotion:
-		_cursor.global_position = xform_vector2(event.global_position)
 		if performing_stroke:
 			_cursor.set_pressure(event.pressure)
 			remove_last_stroke_point()

--- a/lorien/InfiniteCanvas/Tools/RectangleTool.gd
+++ b/lorien/InfiniteCanvas/Tools/RectangleTool.gd
@@ -13,7 +13,6 @@ func tool_event(event: InputEvent) -> void:
 	_cursor.set_pressure(1.0)
 	
 	if event is InputEventMouseMotion:
-		_cursor.global_position = xform_vector2(event.global_position)
 		if performing_stroke:
 			_cursor.set_pressure(event.pressure)
 			remove_all_stroke_points()

--- a/lorien/InfiniteCanvas/Tools/SelectionTool.gd
+++ b/lorien/InfiniteCanvas/Tools/SelectionTool.gd
@@ -100,7 +100,6 @@ func tool_event(event: InputEvent) -> void:
 	# Mouse movement: move the selection
 	elif event is InputEventMouseMotion:
 		var event_pos := xform_vector2(event.global_position)
-		_cursor.global_position = event_pos
 		if _state == State.SELECTING:
 			_selecting_end_pos = event_pos
 			compute_selection(_selecting_start_pos, _selecting_end_pos)

--- a/lorien/project.godot
+++ b/lorien/project.godot
@@ -470,6 +470,26 @@ canvas_zoom_out={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":45,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+canvas_pan_up={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+canvas_pan_down={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+canvas_pan_left={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+canvas_pan_right={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [locale]
 

--- a/lorien/project.godot
+++ b/lorien/project.godot
@@ -460,6 +460,16 @@ shortcut_export_project={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":true,"command":true,"pressed":false,"scancode":69,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+canvas_zoom_in={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":43,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+canvas_zoom_out={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":45,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [locale]
 


### PR DESCRIPTION
This is the one that I really was interested in (especially the zoom).

Maybe also addresses: #147 (?)

https://user-images.githubusercontent.com/542105/177951522-daef7bbb-9e5e-41f6-8d3e-03eb4dd07db8.mp4

- Adds keybinding actions for panning the canvas and zooming. Default keybindings: Arrow keys and +/- for zooming
- Refactored the way cursors update their position, making the cursors themselves responsible for updating their location. Removed cursor position updates from all tools.
    - Had to be done, because panning was causing the cursor location to shift and adding the fix to that to all tools seemed like an extreme amount of code duplication.
