### PR TITLE
Sort keybindings by translated name

### DIFF
--- a/lorien/UI/Dialogs/KeyBindingsList.gd
+++ b/lorien/UI/Dialogs/KeyBindingsList.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 	GlobalSignals.connect("language_changed", self, "_populate_input_list")
 
 # -------------------------------------------------------------------------------------------------
-func _second_element(a: Array, b: Array) -> bool:
+func _compare_second_element(a: Array, b: Array) -> bool:
 	return a[1] < b[1] 
 
 # -------------------------------------------------------------------------------------------------
@@ -33,7 +33,7 @@ func _populate_input_list() -> void:
 		
 		collected_keybinding_args.append([action, translated_action, shortcuts])
 
-	collected_keybinding_args.sort_custom(self, "_second_element")
+	collected_keybinding_args.sort_custom(self, "_compare_second_element")
 	for args in collected_keybinding_args:
 		callv("_new_keybinding_entry", args)
 

--- a/lorien/UI/Dialogs/KeyBindingsList.gd
+++ b/lorien/UI/Dialogs/KeyBindingsList.gd
@@ -14,10 +14,15 @@ func _ready() -> void:
 	GlobalSignals.connect("language_changed", self, "_populate_input_list")
 
 # -------------------------------------------------------------------------------------------------
+func _second_element(a: Array, b: Array) -> bool:
+	return a[1] < b[1] 
+
+# -------------------------------------------------------------------------------------------------
 func _populate_input_list() -> void:
 	for c in _grid.get_children():
 		_grid.remove_child(c)
 	
+	var collected_keybinding_args := []
 	for action in Utils.bindable_actions():
 		var translated_action = Utils.translate_action(action)
 		var shortcuts = []
@@ -25,8 +30,12 @@ func _populate_input_list() -> void:
 			if _event is InputEventKey:
 				var event = _event as InputEventKey
 				shortcuts.append(event)
+		
+		collected_keybinding_args.append([action, translated_action, shortcuts])
 
-		_new_keybinding_entry(action, translated_action, shortcuts)
+	collected_keybinding_args.sort_custom(self, "_second_element")
+	for args in collected_keybinding_args:
+		callv("_new_keybinding_entry", args)
 
 # -------------------------------------------------------------------------------------------------
 func _new_keybinding_entry(action_name: String, readable_name: String, events: Array) -> void:


### PR DESCRIPTION
Sorts the keybindings by their translated string.

Fixes #179