### PR TITLE
Platform UI scaling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Changing the application language does not require a restart now
 - Completed Spanish translation
+- Improved UI auto scaling, especially for Windows and OSX
 
 ## [0.5.0] - 2022-06-12
 

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -533,6 +533,7 @@ func _on_scale_changed() -> void:
 	match auto_scale:
 		Types.UIScale.AUTO:   scale = _get_platform_ui_scale()
 		Types.UIScale.CUSTOM: scale = Settings.get_value(Settings.APPEARANCE_UI_SCALE, Config.DEFAULT_UI_SCALE)
+	scale = clamp(scale, _settings_dialog.get_min_ui_scale(), _settings_dialog.get_max_ui_scale())
 
 	_canvas.set_canvas_scale(scale)
 	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, Vector2(0,0), scale)
@@ -545,18 +546,5 @@ func _get_platform_ui_scale() -> float:
 	match platform:
 		"OSX": scale = OS.get_screen_scale()
 		"Windows": scale = OS.get_screen_dpi() / 96.0
-		"X11": scale = _get_general_scale()
+		_: scale = Config.DEFAULT_UI_SCALE
 	return scale
-
-# --------------------------------------------------------------------------------------------------
-func _get_general_scale() -> float:
-	# Copied from Godot EditorSettings::get_auto_display_scale()
-	# https://github.com/godotengine/godot/blob/3.x/editor/editor_settings.cpp
-	var smallest_dimension: int = min(OS.get_screen_size().x, OS.get_screen_size().y)
-	if OS.get_screen_dpi() >= 192 && smallest_dimension >= 1400:
-		return 2.0
-	elif smallest_dimension >= 1700:
-		return 1.5
-	elif smallest_dimension <= 800:
-		return 0.75
-	return 1.0

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -544,7 +544,7 @@ func _get_platform_ui_scale() -> float:
 	var platform: String = OS.get_name()
 	var scale: float
 	match platform:
-		"OSX": scale = OS.get_screen_scale()
+		"OSX":     scale = OS.get_screen_scale()
 		"Windows": scale = OS.get_screen_dpi() / 96.0
-		_: scale = Config.DEFAULT_UI_SCALE
+		_:         scale = max(stepify(OS.get_screen_size().x / ProjectSettings.get_setting("display/window/size/width"), 0.1), 1)
 	return scale

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -546,5 +546,16 @@ func _get_platform_ui_scale() -> float:
 	match platform:
 		"OSX":     scale = OS.get_screen_scale()
 		"Windows": scale = OS.get_screen_dpi() / 96.0
-		_:         scale = max(stepify(OS.get_screen_size().x / ProjectSettings.get_setting("display/window/size/width"), 0.1), Config.DEFAULT_UI_SCALE)
+		_:         scale = _get_general_ui_scale()
 	return scale
+
+# --------------------------------------------------------------------------------------------------
+func _get_general_ui_scale() -> float:
+	# Adapted from Godot EditorSettings::get_auto_display_scale()
+	# https://github.com/godotengine/godot/blob/3.x/editor/editor_settings.cpp
+	var smallest_dimension: int = min(OS.get_screen_size().x, OS.get_screen_size().y)
+	if OS.get_screen_dpi() >= 192 && smallest_dimension >= 1400:
+		return Config.DEFAULT_UI_SCALE * 2
+	elif smallest_dimension >= 1700:
+		return Config.DEFAULT_UI_SCALE * 1.5
+	return Config.DEFAULT_UI_SCALE

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -531,9 +531,32 @@ func _on_scale_changed() -> void:
 	var auto_scale: int = Settings.get_value(Settings.APPEARANCE_UI_SCALE_MODE, Config.DEFAULT_UI_SCALE_MODE)
 	var scale: float
 	match auto_scale:
-		Types.UIScale.AUTO:   scale = OS.get_screen_size().x / ProjectSettings.get_setting("display/window/size/width")
+		Types.UIScale.AUTO:   scale = _get_platform_ui_scale()
 		Types.UIScale.CUSTOM: scale = Settings.get_value(Settings.APPEARANCE_UI_SCALE, Config.DEFAULT_UI_SCALE)
 
 	_canvas.set_canvas_scale(scale)
 	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, Vector2(0,0), scale)
 	OS.min_window_size = Config.MIN_WINDOW_SIZE * scale
+
+# --------------------------------------------------------------------------------------------------
+func _get_platform_ui_scale() -> float:
+	var platform: String = OS.get_name()
+	var scale: float
+	match platform:
+		"OSX": scale = OS.get_screen_scale()
+		"Windows": scale = OS.get_screen_dpi() / 96.0
+		"X11": scale = _get_general_scale()
+	return scale
+
+# --------------------------------------------------------------------------------------------------
+func _get_general_scale() -> float:
+	# Copied from Godot EditorSettings::get_auto_display_scale()
+	# https://github.com/godotengine/godot/blob/3.x/editor/editor_settings.cpp
+	var smallest_dimension: int = min(OS.get_screen_size().x, OS.get_screen_size().y)
+	if OS.get_screen_dpi() >= 192 && smallest_dimension >= 1400:
+		return 2.0
+	elif smallest_dimension >= 1700:
+		return 1.5
+	elif smallest_dimension <= 800:
+		return 0.75
+	return 1.0

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -546,5 +546,5 @@ func _get_platform_ui_scale() -> float:
 	match platform:
 		"OSX":     scale = OS.get_screen_scale()
 		"Windows": scale = OS.get_screen_dpi() / 96.0
-		_:         scale = max(stepify(OS.get_screen_size().x / ProjectSettings.get_setting("display/window/size/width"), 0.1), 1)
+		_:         scale = max(stepify(OS.get_screen_size().x / ProjectSettings.get_setting("display/window/size/width"), 0.1), Config.DEFAULT_UI_SCALE)
 	return scale

--- a/lorien/UI/Dialogs/SettingsDialog.gd
+++ b/lorien/UI/Dialogs/SettingsDialog.gd
@@ -114,7 +114,7 @@ func _set_languages(current_locale: String) -> void:
 #--------------------------------------------------------------------------------------------------
 func _set_UIScale_range():
 	var screen_scale_max: float = (OS.get_screen_size().x * OS.get_screen_size().y) / (ProjectSettings.get_setting("display/window/size/width") * ProjectSettings.get_setting("display/window/size/height"))
-	var screen_scale_min: float = max(OS.get_screen_size().x, OS.get_screen_size().y) / ProjectSettings.get_setting("display/window/size/width")
+	var screen_scale_min: float = OS.get_screen_size().x / ProjectSettings.get_setting("display/window/size/width")
 	_ui_scale.min_value = max(screen_scale_min / 2, 0.5)
 	_ui_scale.max_value = screen_scale_max + 1.5
 

--- a/lorien/UI/Dialogs/SettingsDialog.gd
+++ b/lorien/UI/Dialogs/SettingsDialog.gd
@@ -113,9 +113,10 @@ func _set_languages(current_locale: String) -> void:
 
 #--------------------------------------------------------------------------------------------------
 func _set_UIScale_range():
-	var screen_scale: float = (OS.get_screen_size().x * OS.get_screen_size().y) / (ProjectSettings.get_setting("display/window/size/width") * ProjectSettings.get_setting("display/window/size/height"))
-	_ui_scale.min_value = screen_scale / 2
-	_ui_scale.max_value = screen_scale + 1.5
+	var screen_scale_max: float = (OS.get_screen_size().x * OS.get_screen_size().y) / (ProjectSettings.get_setting("display/window/size/width") * ProjectSettings.get_setting("display/window/size/height"))
+	var screen_scale_min: float = max(OS.get_screen_size().x, OS.get_screen_size().y) / ProjectSettings.get_setting("display/window/size/width")
+	_ui_scale.min_value = max(screen_scale_min / 2, 0.5)
+	_ui_scale.max_value = screen_scale_max + 1.5
 
 #--------------------------------------------------------------------------------------------------
 func get_max_ui_scale() -> float:

--- a/lorien/UI/Dialogs/SettingsDialog.gd
+++ b/lorien/UI/Dialogs/SettingsDialog.gd
@@ -113,9 +113,17 @@ func _set_languages(current_locale: String) -> void:
 
 #--------------------------------------------------------------------------------------------------
 func _set_UIScale_range():
-	var screen_scale: float = OS.get_screen_size().x / ProjectSettings.get_setting("display/window/size/width")
+	var screen_scale: float = (OS.get_screen_size().x * OS.get_screen_size().y) / (ProjectSettings.get_setting("display/window/size/width") * ProjectSettings.get_setting("display/window/size/height"))
 	_ui_scale.min_value = screen_scale / 2
 	_ui_scale.max_value = screen_scale + 1.5
+
+#--------------------------------------------------------------------------------------------------
+func get_max_ui_scale() -> float:
+	return _ui_scale.max_value
+
+#--------------------------------------------------------------------------------------------------
+func get_min_ui_scale() -> float:
+	return _ui_scale.min_value
 
 # -------------------------------------------------------------------------------------------------
 func _on_DefaultBrushSize_value_changed(value: int) -> void:


### PR DESCRIPTION
Calculate UI auto scaling based on platform for more accurate scaling. Also wider range of allowed UI scales for some displays.

The scaling for Linux could probably be improved further, but will be much easier if Godot implements better scaling/dpi support in the engine itself.