### PR TITLE
Add Linux metadata files

### DIFF
--- a/public/linux/com.github.mbrlabs.Lorien.desktop
+++ b/public/linux/com.github.mbrlabs.Lorien.desktop
@@ -2,8 +2,8 @@
 Type=Application
 Name=Lorien
 GenericName=Note Taking
-Comment=Infinite canvas drawing/whiteboarding app. Made with Godot.
-Comment[de]=Unbegrenzte Zeichen- und Whiteboard-App. Erstellt mit Godot.
+Comment=Infinite canvas drawing/whiteboarding app
+Comment[de]=Freie Zeichen- und Whiteboard-App
 Icon=com.github.mbrlabs.Lorien
 Exec=Lorien %U
 Terminal=false

--- a/public/linux/com.github.mbrlabs.Lorien.desktop
+++ b/public/linux/com.github.mbrlabs.Lorien.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=Lorien
+GenericName=Note Taking
+Comment=Infinite canvas drawing/whiteboarding app. Made with Godot.
+Comment[de]=Unbegrenzte Zeichen- und Whiteboard-App. Erstellt mit Godot.
+Icon=com.github.mbrlabs.Lorien
+Exec=Lorien %U
+Terminal=false
+MimeType=application/lorien
+Categories=Graphics;
+Keywords=Drawing;Handwriting;Whiteboard
+StartupWMClass=Lorien

--- a/public/linux/com.github.mbrlabs.Lorien.metainfo.xml
+++ b/public/linux/com.github.mbrlabs.Lorien.metainfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.github.mbrlabs.Lorien</id>
+
+  <name>Lorien</name>
+  <summary>Infinite canvas drawing/whiteboarding app. Made with Godot.</summary>
+  <summary xml:lang="de_DE">Unbegrenzte Zeichen- und Whiteboard-App. Erstellt mit Godot.</summary>
+
+  <url type="homepage">https://github.com/mbrlabs/Lorien</url>
+  <url type="bugtracker">https://github.com/mbrlabs/Lorien/issues</url>
+  <url type="help">https://github.com/mbrlabs/Lorien/blob/main/docs/manuals</url>
+  <url type="donation">https://ko-fi.com/mbrlabs</url>
+  <url type="translate">https://github.com/mbrlabs/Lorien/blob/main/docs/i18n.md</url>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <content_rating type="oars-1.1"/>
+
+  <launchable type="desktop-id">com.github.mbrlabs.Lorien.desktop</launchable>
+
+  <description>
+    <p>Lorien is an infinite canvas drawing/note-taking app that is focused on performance, small savefiles and simplicity.</p>
+    <p>It's not based on bitmap images like Krita, Gimp or Photoshop; it rather saves brush strokes as a collection of points and renders them at runtime (kind of like SVG).</p>
+    <p>It's primarily designed to be used as a digital notebook and as brainstorming tool.</p>
+    <p>While it can totally be used to make small sketches and diagrams, it is not meant to replace traditional art programs that operate on bitmap images.</p>
+    <p>It is entirely written in the Godot Game Engine.</p>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/mbrlabs/Lorien/main/images/lorien_demo.png</image>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="0.5.0" date="2022-06-12"/>
+  </releases>
+</component>

--- a/public/linux/com.github.mbrlabs.Lorien.metainfo.xml
+++ b/public/linux/com.github.mbrlabs.Lorien.metainfo.xml
@@ -3,8 +3,8 @@
   <id>com.github.mbrlabs.Lorien</id>
 
   <name>Lorien</name>
-  <summary>Infinite canvas drawing/whiteboarding app. Made with Godot.</summary>
-  <summary xml:lang="de_DE">Unbegrenzte Zeichen- und Whiteboard-App. Erstellt mit Godot.</summary>
+  <summary>Infinite canvas drawing/whiteboarding app</summary>
+  <summary xml:lang="de_DE">Freie Zeichen- und Whiteboard-App</summary>
 
   <url type="homepage">https://github.com/mbrlabs/Lorien</url>
   <url type="bugtracker">https://github.com/mbrlabs/Lorien/issues</url>

--- a/public/linux/com.github.mbrlabs.Lorien.mimetype.xml
+++ b/public/linux/com.github.mbrlabs.Lorien.mimetype.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+   <mime-type type="application/lorien">
+     <comment>Lorien Canvas file</comment>
+     <glob pattern="*.lorien"/>
+   </mime-type>
+</mime-info>

--- a/public/linux/x-lorien-canvas.mimetype.xml
+++ b/public/linux/x-lorien-canvas.mimetype.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
-   <mime-type type="application/lorien">
+   <mime-type type="application/x-lorien-canvas">
      <comment>Lorien Canvas file</comment>
+     <comment xml:lang="de">Lorien Zeichnung</comment>
      <glob pattern="*.lorien"/>
    </mime-type>
 </mime-info>


### PR DESCRIPTION
This PR adds metadata files required for packaging on Linux, for example Flatpak. See https://github.com/mbrlabs/Lorien/issues/17.

The files are currently stored in [tinywrkb's Flatpak repo](https://github.com/tinywrkb/flathub/tree/com.github.mbrlabs.Lorien) but it is recommended to have the files in the upstream repository so they are the same for all packages and can easily be modified by the upstream author.