### PR TITLE
SelectionTool: fix missing cursor on initial usage

### DIFF
--- a/lorien/InfiniteCanvas/Tools/SelectionTool.gd
+++ b/lorien/InfiniteCanvas/Tools/SelectionTool.gd
@@ -33,6 +33,7 @@ var _bounding_box_cache = {} # BrushStroke -> Rect2
 # ------------------------------------------------------------------------------------------------
 func _ready():
 	_selection_rectangle = get_node(selection_rectangle_path)
+	_cursor.mode = SelectionCursor.Mode.SELECT
 
 # ------------------------------------------------------------------------------------------------
 func tool_event(event: InputEvent) -> void:


### PR DESCRIPTION
Fixes missing on-canvas cursor when switching to SelectionTool for the first time.

Fixes bug introduced by: bc83fbe6691c (`Reset state of tool being switched (#155)`)