### PR TITLE
Minor changes to remove checks for logically impossible situations

### DIFF
--- a/lorien/InfiniteCanvas/Tools/BrushTool.gd
+++ b/lorien/InfiniteCanvas/Tools/BrushTool.gd
@@ -24,12 +24,12 @@ func tool_event(event: InputEvent) -> void:
 		if performing_stroke:
 			_cursor.set_pressure(event.pressure)
 
-	if event is InputEventMouseButton:
+	elif event is InputEventMouseButton:
 		if event.button_index == BUTTON_LEFT:
 			if event.pressed:
 				start_stroke()
 				_first_point = true
-			elif !event.pressed && performing_stroke:
+			elif performing_stroke:
 				end_stroke()
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Two changes:
1. The tool_event InputEvent is either a MouseMotion or a MouseButton, so the check for the InputEvent being a MouseButton event does not need to occur if the object is already identified as a MouseMotion.
2. In the tool_event MouseButton path, if the elif section is reached then event.pressed is guaranteed to be false, so checking that it is false is redundant.