### PR TITLE
"Reset to Center" and "Zoom to Drawing" Functions

### DIFF
--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -56,6 +56,8 @@ STATUSBAR_PRESSURE              Pressure
 STATUSBAR_FPS                   FPS
 STATUSBAR_STROKES               Strokes
 STATUSBAR_POINTS                Points
+STATUSBAR_TOOLTIP_POSITION      Reset Position
+STATUSBAR_TOOLTIP_ZOOM          Reset Zoom
 
 # -----------------------------------------------------------------------------
 # Settings strings

--- a/lorien/InfiniteCanvas/InfiniteCanvas.gd
+++ b/lorien/InfiniteCanvas/InfiniteCanvas.gd
@@ -388,3 +388,11 @@ func _undo_delete_stroke(stroke: BrushStroke) -> void:
 	_strokes_parent.add_child(stroke)
 	info.point_count += stroke.points.size()
 	info.stroke_count += 1
+	
+# -------------------------------------------------------------------------------------------------
+func reset_position():
+	_camera.reset_position()
+
+# -------------------------------------------------------------------------------------------------
+func reset_zoom():
+	_camera.reset_zoom()

--- a/lorien/InfiniteCanvas/PanZoomCamera.gd
+++ b/lorien/InfiniteCanvas/PanZoomCamera.gd
@@ -19,6 +19,9 @@ var _zoom_active := false
 var _current_zoom_level := 1.0
 var _start_mouse_pos := Vector2(0.0, 0.0)
 
+@onready var _topbar : VBoxContainer = get_node("/root/Main/Topbar")
+@onready var _statusbar : Panel = get_node("/root/Main/Statusbar")
+
 # -------------------------------------------------------------------------------------------------
 var _touch_events = {}
 var _touch_last_drag_distance := 0.0
@@ -179,3 +182,63 @@ func xform(pos: Vector2) -> Vector2:
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_WM_MOUSE_EXIT:
 		_pan_active = false
+		
+# -------------------------------------------------------------------------------------------------
+func reset_position():
+	offset = Vector2(0.0,0.0)
+	emit_signal("position_changed", offset)
+
+# -------------------------------------------------------------------------------------------------
+func reset_zoom():
+	var max_dim : Vector2 = BrushStroke.MIN_VECTOR2
+	var min_dim : Vector2 = BrushStroke.MAX_VECTOR2
+	var project: Project = ProjectManager.get_active_project()
+	var zoom_steps_x : int = 0
+	var zoom_steps_y : int = 0
+	var zoom_x : float = 1
+	var zoom_y :float = 1
+	var final_zoom : float
+	var zoomed_viewport_size : Vector2 = get_viewport().size
+
+	print(project.strokes.size())
+	if project.strokes.is_empty():
+		reset_position()
+	else:
+		#subtract UI size from viewport if it is visible
+		if _topbar.visible && _statusbar.visible:
+			zoomed_viewport_size.y = zoomed_viewport_size.y-(_topbar.get_rect().size.y+_statusbar.get_rect().size.y)
+		for stroke in project.strokes:
+			min_dim.x = min(min_dim.x, stroke.top_left_pos.x)
+			min_dim.y = min(min_dim.y, stroke.top_left_pos.y)
+			max_dim.x = max(max_dim.x, stroke.bottom_right_pos.x)
+			max_dim.y = max(max_dim.y, stroke.bottom_right_pos.y)
+
+		var diff_max_dim = Vector2(abs(max_dim.x-min_dim.x), abs(max_dim.y-min_dim.y))
+
+		while diff_max_dim.x > zoomed_viewport_size.x:
+			zoomed_viewport_size.x = zoomed_viewport_size.x * 1.1
+			zoom_x = zoom_x/1.1
+			zoom_steps_x = zoom_steps_x + 1
+
+		while diff_max_dim.y > zoomed_viewport_size.y:
+			zoomed_viewport_size.y = zoomed_viewport_size.y * 1.1
+			zoom_y = zoom_y/1.1
+			zoom_steps_y = zoom_steps_y +1
+
+		if zoom_steps_x > zoom_steps_y:
+			final_zoom = zoom_x
+		else:
+			final_zoom = zoom_y
+
+		var anchor = Vector2(min_dim.x+get_viewport().size.x/2, min_dim.y+get_viewport().size.y/2)
+
+		final_zoom = final_zoom / 1.1
+		var center_offset : Vector2
+		center_offset.x = ((1/final_zoom)*get_viewport().size.x)-diff_max_dim.x
+		center_offset.y = ((1/final_zoom)*(get_viewport().size.y))-diff_max_dim.y
+
+		_zoom_canvas(final_zoom, anchor)
+		offset = min_dim
+		offset.y = offset.y-((center_offset.y)/2)
+		offset.x = offset.x-(center_offset.x/2)
+		emit_signal("position_changed", offset)

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -636,3 +636,11 @@ func _on_theme_changed(path : String) -> void:
 	_settings_dialog.queue_redraw()
 	queue_redraw()
 	print(theme)
+
+# --------------------------------------------------------------------------------------------------
+func _on_statusbar_reset_position() -> void:
+	_canvas.reset_position()
+
+# --------------------------------------------------------------------------------------------------
+func _on_statusbar_reset_zoom() -> void:
+	_canvas.reset_zoom()

--- a/lorien/Main.tscn
+++ b/lorien/Main.tscn
@@ -191,3 +191,6 @@ size = Vector2i(625, 175)
 theme = ExtResource("8")
 access = 2
 use_native_dialog = true
+
+[connection signal="resetPosition" from="Statusbar" to="." method="_on_statusbar_reset_position"]
+[connection signal="resetZoom" from="Statusbar" to="." method="_on_statusbar_reset_zoom"]

--- a/lorien/UI/Statusbar.gd
+++ b/lorien/UI/Statusbar.gd
@@ -9,6 +9,9 @@ class_name Statusbar
 @onready var _zoom_label: Label = $MarginContainer/HBoxContainer/Left/ZoomLabel
 @onready var _fps_label: Label = $MarginContainer/HBoxContainer/Left/FpsLabel
 
+signal resetPosition
+signal resetZoom
+
 var _str_position: String
 var _str_zoom: String
 var _str_pressure: String
@@ -32,11 +35,11 @@ func _apply_language() -> void:
 
 # -------------------------------------------------------------------------------------------------
 func set_camera_position(pos: Vector2) -> void:
-	_position_label.text = "%s: %d, %d" % [_str_position, pos.x, pos.y]
+	_position_label.text = " %d, %d" % [pos.x, pos.y]
 
 # -------------------------------------------------------------------------------------------------
 func set_camera_zoom(zoom: float) -> void:
-	_zoom_label.text = "%s: %.1f" % [_str_zoom, zoom]
+	_zoom_label.text = " %.1f" % [ zoom]
 
 # -------------------------------------------------------------------------------------------------
 func set_fps(fps: int) -> void:
@@ -56,3 +59,11 @@ func set_stroke_count(brush_stroke_count: int) -> void:
 # -------------------------------------------------------------------------------------------------
 func set_point_count(point_count: int) -> void:
 	_points_label.text = "%s: %d" % [_str_point_count, point_count]
+
+# -------------------------------------------------------------------------------------------------
+func _on_position_reset_button_pressed() -> void:
+	resetPosition.emit()
+
+# -------------------------------------------------------------------------------------------------
+func _on_zoom_reset_button_pressed() -> void:
+	resetZoom.emit()

--- a/lorien/UI/Statusbar.tscn
+++ b/lorien/UI/Statusbar.tscn
@@ -15,6 +15,7 @@ script = ExtResource("2")
 layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 0
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_right = 10
 
@@ -27,13 +28,26 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 0
 
+[node name="PositionResetButton" type="Button" parent="MarginContainer/HBoxContainer/Left"]
+custom_minimum_size = Vector2(55, 0)
+layout_mode = 2
+tooltip_text = "Reset Position"
+theme_type_variation = &"StatusBarButton"
+text = "Position:"
+
 [node name="PositionLabel" type="Label" parent="MarginContainer/HBoxContainer/Left"]
 layout_mode = 2
-text = "Position: -"
 
 [node name="Sep" type="Label" parent="MarginContainer/HBoxContainer/Left"]
 layout_mode = 2
 text = "|"
+
+[node name="ZoomResetButton" type="Button" parent="MarginContainer/HBoxContainer/Left"]
+custom_minimum_size = Vector2(45, 0)
+layout_mode = 2
+tooltip_text = "Reset Zoom"
+theme_type_variation = &"StatusBarButton"
+text = "Zoom:"
 
 [node name="ZoomLabel" type="Label" parent="MarginContainer/HBoxContainer/Left"]
 layout_mode = 2
@@ -73,3 +87,6 @@ text = "|"
 [node name="PointsLabel" type="Label" parent="MarginContainer/HBoxContainer/Right"]
 layout_mode = 2
 text = "Points: 0"
+
+[connection signal="pressed" from="MarginContainer/HBoxContainer/Left/PositionResetButton" to="." method="_on_position_reset_button_pressed"]
+[connection signal="pressed" from="MarginContainer/HBoxContainer/Left/ZoomResetButton" to="." method="_on_zoom_reset_button_pressed"]

--- a/lorien/UI/Themes/dark/theme.tres
+++ b/lorien/UI/Themes/dark/theme.tres
@@ -1,6 +1,5 @@
-[gd_resource type="Theme" load_steps=28 format=4 uid="uid://u5qnpgxqykiv"]
+[gd_resource type="Theme" load_steps=33 format=4 uid="uid://u5qnpgxqykiv"]
 
-[ext_resource type="Texture2D" uid="uid://bp1yka17gbjtu" path="res://Assets/Icons/close.png" id="1_qgxa7"]
 [ext_resource type="StyleBox" uid="uid://kdduww61cjw" path="res://UI/Themes/dark/tab_inactive.tres" id="2_n6mkw"]
 [ext_resource type="StyleBox" uid="uid://dtn7ehcyfik4a" path="res://UI/Themes/dark/tab_active.tres" id="3_rqnin"]
 
@@ -137,6 +136,31 @@ shadow_size = 4
 color = Color(1, 1, 1, 0.1)
 grow_begin = 7.0
 grow_end = 7.0
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_cwfso"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_t2rrf"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_i5a3g"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_jp7y7"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q0dxl"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
 
 [sub_resource type="Image" id="Image_phhbj"]
 data = {
@@ -2568,6 +2592,12 @@ PopupMenu/styles/labeled_separator_right = null
 PopupMenu/styles/panel = SubResource("15")
 PopupMenu/styles/panel_disabled = null
 PopupMenu/styles/separator = SubResource("16")
+StatusBarButton/base_type = &"Button"
+StatusBarButton/styles/focus = SubResource("StyleBoxEmpty_cwfso")
+StatusBarButton/styles/hover = SubResource("StyleBoxFlat_t2rrf")
+StatusBarButton/styles/hover_pressed = SubResource("StyleBoxFlat_i5a3g")
+StatusBarButton/styles/normal = SubResource("StyleBoxEmpty_jp7y7")
+StatusBarButton/styles/pressed = SubResource("StyleBoxFlat_q0dxl")
 TabBar/colors/drop_mark_color = Color(1, 1, 1, 1)
 TabBar/colors/font_disabled_color = Color(0.875, 0.875, 0.875, 0.5)
 TabBar/colors/font_hovered_color = Color(0.95, 0.95, 0.95, 1)
@@ -2578,7 +2608,7 @@ TabBar/constants/h_separation = 4
 TabBar/constants/icon_max_width = 0
 TabBar/constants/outline_size = 0
 TabBar/fonts/font = SubResource("FontFile_1bm21")
-TabBar/icons/close = ExtResource("1_qgxa7")
+TabBar/icons/close = null
 TabBar/styles/button_highlight = SubResource("StyleBoxEmpty_me351")
 TabBar/styles/button_pressed = SubResource("StyleBoxEmpty_n0chp")
 TabBar/styles/tab_disabled = ExtResource("2_n6mkw")

--- a/lorien/UI/Themes/light/theme.tres
+++ b/lorien/UI/Themes/light/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=27 format=4 uid="uid://cf4gyeqbly7p8"]
+[gd_resource type="Theme" load_steps=32 format=4 uid="uid://cf4gyeqbly7p8"]
 
 [ext_resource type="Texture2D" uid="uid://bp1yka17gbjtu" path="res://Assets/Icons/close.png" id="1_52p0o"]
 [ext_resource type="StyleBox" uid="uid://kdduww61cjw" path="res://UI/Themes/dark/tab_inactive.tres" id="2_6sj5t"]
@@ -123,6 +123,28 @@ shadow_size = 4
 color = Color(1, 1, 1, 0.1)
 grow_begin = 7.0
 grow_end = 7.0
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_n8mvn"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_47yds"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.306923, 0.306923, 0.306922, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2n2l1"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.306923, 0.306923, 0.306922, 1)
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_buc1g"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_vp7ww"]
 
 [sub_resource type="Image" id="Image_phhbj"]
 data = {
@@ -2433,7 +2455,7 @@ content_margin_left = 6.0
 content_margin_top = 6.0
 content_margin_right = 6.0
 content_margin_bottom = 6.0
-bg_color = Color(0.12549, 0.129412, 0.141176, 1)
+bg_color = Color(1, 1, 1, 1)
 shadow_color = Color(0, 0, 0, 0.317647)
 shadow_size = 4
 
@@ -2552,6 +2574,17 @@ PopupMenu/styles/labeled_separator_right = null
 PopupMenu/styles/panel = SubResource("15")
 PopupMenu/styles/panel_disabled = null
 PopupMenu/styles/separator = SubResource("16")
+StatusBarButton/base_type = &"Button"
+StatusBarButton/colors/font_color = Color(0, 0, 0, 1)
+StatusBarButton/colors/font_focus_color = Color(0, 0, 0, 1)
+StatusBarButton/colors/font_hover_color = Color(0, 0, 0, 1)
+StatusBarButton/colors/font_hover_pressed_color = Color(0, 0, 0, 1)
+StatusBarButton/colors/font_pressed_color = Color(0, 0, 0, 1)
+StatusBarButton/styles/focus = SubResource("StyleBoxEmpty_n8mvn")
+StatusBarButton/styles/hover = SubResource("StyleBoxFlat_47yds")
+StatusBarButton/styles/hover_pressed = SubResource("StyleBoxFlat_2n2l1")
+StatusBarButton/styles/normal = SubResource("StyleBoxEmpty_buc1g")
+StatusBarButton/styles/pressed = SubResource("StyleBoxEmpty_vp7ww")
 TabBar/colors/drop_mark_color = Color(1, 1, 1, 1)
 TabBar/colors/font_disabled_color = Color(0.875, 0.875, 0.875, 0.5)
 TabBar/colors/font_hovered_color = Color(0.95, 0.95, 0.95, 1)


### PR DESCRIPTION
As described in #233 I have created two new buttons in the toolbar. One for resetting the camera to center/home (position 0/0 with Zoom 1) and one that zooms out so that the whole drawing is shown.

![image](https://github.com/mbrlabs/Lorien/assets/17379814/10eeeea4-470f-40e9-a8a4-b8c1e5447d97)

I'm not sure if the Icons are clear enough. So I'm open for suggestions. Additionally they don't match exactly the style of the others.

*Known issues with this solution:*
- If it would be necessary to zoom out further than 100 to see the whole drawing, it stops at the limit of 100 and only shows a part of the drawing.
- In some cases, if the window is very small, a small part of the drawing may be hidden under the toolbar when zoom to drawing.