### PR TITLE
feat: Add default keybind "P" for palette toggle

### DIFF
--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -158,6 +158,7 @@ ACTION_shortcut_select_tool        Selection tool
 ACTION_shortcut_move_tool          Move tool
 ACTION_shortcut_rectangle_tool     Rectangle tool
 ACTION_shortcut_circle_tool        Circle tool
+ACTION_shortcut_palette_tool       Palette tool
 ACTION_shortcut_export_project     Export project
 ACTION_deselect_all_strokes        Deselect all strokes
 ACTION_center_canvas_to_mouse      Space

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -164,6 +164,8 @@ func _unhandled_input(event):
 				_toggle_distraction_free_mode()
 			elif Utils.event_pressed_bug_workaround("toggle_fullscreen", event):
 				_toggle_fullscreen()
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_tool", event):
+				_brush_color_picker.toggle()
 
 # -------------------------------------------------------------------------------------------------
 func _toggle_player() -> void:

--- a/lorien/project.godot
+++ b/lorien/project.godot
@@ -490,6 +490,11 @@ canvas_pan_right={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+shortcut_palette_tool={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":80,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [locale]
 


### PR DESCRIPTION
Toggle the color picker palette with the key "P".  This is a first step towards picking colors from the keyboard directly (similar to how the other tools work).