### PR TITLE
feat: keymaps for color selection (#251)

### DIFF
--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -174,6 +174,17 @@ ACTION_canvas_pan_up               Pan up
 ACTION_canvas_pan_down             Pan down
 ACTION_canvas_pan_right            Pan right
 ACTION_canvas_pan_left             Pan left
+ACTION_shortcut_palette_ui_toggle  Palette UI toggle
+ACTION_shortcut_palette_select_color_0  Select palette color 0
+ACTION_shortcut_palette_select_color_1  Select palette color 1
+ACTION_shortcut_palette_select_color_2  Select palette color 2
+ACTION_shortcut_palette_select_color_3  Select palette color 3
+ACTION_shortcut_palette_select_color_4  Select palette color 4
+ACTION_shortcut_palette_select_color_5  Select palette color 5
+ACTION_shortcut_palette_select_color_6  Select palette color 6
+ACTION_shortcut_palette_select_color_7  Select palette color 7
+ACTION_shortcut_palette_select_color_8  Select palette color 8
+ACTION_shortcut_palette_select_color_9  Select palette color 9
 
 # -----------------------------------------------------------------------------
 # Kebindings dialog messages

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -164,6 +164,28 @@ func _unhandled_input(event):
 				_toggle_distraction_free_mode()
 			elif Utils.event_pressed_bug_workaround("toggle_fullscreen", event):
 				_toggle_fullscreen()
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_ui_toggle", event):
+				_brush_color_picker.toggle()
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_0", event):
+				_brush_color_picker._change_brush_color(0)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_1", event):
+				_brush_color_picker._change_brush_color(1)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_2", event):
+				_brush_color_picker._change_brush_color(2)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_3", event):
+				_brush_color_picker._change_brush_color(3)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_4", event):
+				_brush_color_picker._change_brush_color(4)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_5", event):
+				_brush_color_picker._change_brush_color(5)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_6", event):
+				_brush_color_picker._change_brush_color(6)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_7", event):
+				_brush_color_picker._change_brush_color(7)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_8", event):
+				_brush_color_picker._change_brush_color(8)
+			elif Utils.event_pressed_bug_workaround("shortcut_palette_select_color_9", event):
+				_brush_color_picker._change_brush_color(9)
 
 # -------------------------------------------------------------------------------------------------
 func _toggle_player() -> void:

--- a/lorien/UI/ColorPalettePicker.gd
+++ b/lorien/UI/ColorPalettePicker.gd
@@ -109,6 +109,11 @@ func _on_platte_button_pressed(button: PaletteButton, index: int) -> void:
 	emit_signal("color_changed", button.color)
 
 # -------------------------------------------------------------------------------------------------
+func _change_brush_color(color_index: int) -> void:
+	color_index = min(color_index, PaletteManager.get_active_palette().colors.size()-1)
+	_on_platte_button_pressed(_color_grid.get_child(color_index), color_index)
+
+# -------------------------------------------------------------------------------------------------
 func _on_PaletteSelectionButton_item_selected(index: int) -> void:
 	PaletteManager.set_active_palette_by_index(index)
 	PaletteManager.save()

--- a/lorien/project.godot
+++ b/lorien/project.godot
@@ -371,6 +371,61 @@ shortcut_move_tool={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":77,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+shortcut_palette_ui_toggle={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":80,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_0={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":48,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_1={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":49,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_2={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":50,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_3={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":51,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_4={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":52,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_5={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":53,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_6={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":54,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_7={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":55,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_8={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":56,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shortcut_palette_select_color_9={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":57,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 deselect_all_strokes={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"physical_scancode":0,"unicode":0,"echo":false,"script":null)


### PR DESCRIPTION
This commit adds the following keymaps:

- P: toggle the color palette UI
- 0: select palette color 0
- 1: select palette color 1
- 2: select palette color 2
- 3: select palette color 3
- 4: select palette color 4
- 5: select palette color 5
- 6: select palette color 6
- 7: select palette color 7
- 8: select palette color 8
- 9: select palette color 9

If there are fewer than 10 colors in the palette, keymaps for colors
beyond what's in the palette will result in selecting the last color.
For example, if there are 3 colors in the palette and the user presses
4, then color 3 is selected.

For palettes with more than 10 colors, manual selection is still
required for colors after 10.
