### PR TITLE
Disable low processor mode

### DIFF
--- a/lorien/project.godot
+++ b/lorien/project.godot
@@ -226,7 +226,6 @@ _global_script_class_icons={
 
 config/name="Lorien"
 run/main_scene="res://Main.tscn"
-run/low_processor_mode=true
 boot_splash/image="res://Assets/Textures/boot.png"
 boot_splash/fullsize=false
 boot_splash/use_filter=false


### PR DESCRIPTION
The FPS can be limited in settings. Disabling low processor mode allows
the app to run at higher refresh rates if the user desires.  It's
currently locked at 144fps.
