### PR TITLE
Pan with space or any other key

### DIFF
--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -158,6 +158,7 @@ ACTION_duplicate_strokes            Duplicate strokes
 ACTION_toggle_zen_mode              Toggle Zen Mode
 ACTION_toggle_player                Toggle Easteregg
 ACTION_toggle_fullscreen            Toggle Fullscreen
+ACTION_canvas_pan_key               Pan Key
 
 # -----------------------------------------------------------------------------
 # Kebindings dialog messages

--- a/lorien/InfiniteCanvas/PanZoomCamera.gd
+++ b/lorien/InfiniteCanvas/PanZoomCamera.gd
@@ -36,6 +36,12 @@ func do_center(screen_space_center_point: Vector2) -> void:
 # -------------------------------------------------------------------------------------------------
 func tool_event(event: InputEvent) -> void:
 	if _is_input_enabled:
+		if event is InputEventKey:
+			if Utils.event_pressed_bug_workaround("canvas_pan_key", event):
+				_pan_active = event.is_pressed()
+			else:
+				_pan_active = event.is_pressed()
+		
 		if event is InputEventMouseButton:
 			
 			# Scroll wheel up/down to zoom
@@ -112,3 +118,8 @@ func disable_input() -> void:
 # -------------------------------------------------------------------------------------------------
 func xform(pos: Vector2) -> Vector2:
 	return (pos * zoom) + offset
+
+#--------------------------------------------------------------------------------------------------
+func _notification(what):
+	if what == NOTIFICATION_WM_MOUSE_EXIT:
+		_pan_active = false

--- a/lorien/project.godot
+++ b/lorien/project.godot
@@ -237,6 +237,11 @@ player_jump={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+canvas_pan_key={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
 
 [locale]
 


### PR DESCRIPTION
As suggested in the issues #238 and #226, I have added a new input "canvas_pan_key" which allows to pan the viewport the same as the middle mouse button does. 

New input is defaulted to control + space, because I don't want to change the default behavior of the application. But everyone who needs it can configure it to the space bar and replace the "center to mouse position".