### PR TITLE
Updated Godot version to use in contribution guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 ## General
 This guide is loosly based on [Godot's contributing guidelines](https://github.com/godotengine/godot/blob/master/CONTRIBUTING.md):
-- Use the latest stable release: Godot 3.4.4
+- Use the latest stable release: Godot 3.5.x
 - If you want to implement a big feature, open an issue or a [Github discussion](https://github.com/mbrlabs/Lorien/discussions) so we can talk about it first
 - Format your commit messages with readability in mind
 


### PR DESCRIPTION
Since Lorien uses event.pen_inverted, version 3.4.4 is not working anymore.