### PR TITLE
Disable undo/redo buttons when there is nothing to undo/redo

### DIFF
--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -238,6 +238,8 @@ func _on_files_dropped(files: PackedStringArray) -> void:
 
 # -------------------------------------------------------------------------------------------------
 func _make_project_active(project: Project) -> void:
+	var previous_project: Project = ProjectManager.get_active_project()
+	
 	ProjectManager.make_project_active(project)
 	_canvas.use_project(project)
 	
@@ -245,6 +247,8 @@ func _make_project_active(project: Project) -> void:
 		_menubar.make_tab(project)
 	_menubar.set_tab_active(project)
 	
+	_toolbar._on_active_project_changed(previous_project, project)
+
 # -------------------------------------------------------------------------------------------------
 func _is_mouse_on_ui() -> bool:
 	var on_ui := Utils.is_mouse_in_control(_menubar)

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -238,16 +238,12 @@ func _on_files_dropped(files: PackedStringArray) -> void:
 
 # -------------------------------------------------------------------------------------------------
 func _make_project_active(project: Project) -> void:
-	var previous_project: Project = ProjectManager.get_active_project()
-	
 	ProjectManager.make_project_active(project)
 	_canvas.use_project(project)
 	
 	if !_menubar.has_tab(project):
 		_menubar.make_tab(project)
 	_menubar.set_tab_active(project)
-	
-	_toolbar._on_active_project_changed(previous_project, project)
 
 # -------------------------------------------------------------------------------------------------
 func _is_mouse_on_ui() -> bool:

--- a/lorien/ProjectManager/Project.gd
+++ b/lorien/ProjectManager/Project.gd
@@ -1,9 +1,17 @@
 class_name Project
 
+# Emitted whenever something marks the project as dirty, even if it's already dirty.
+signal dirtied
+
 var id: int # this is used at runtime only and will not be persisted; project ids are not garanteed to be the same between restarts
 var undo_redo: UndoRedo
 
-var dirty := false
+var dirty := false:
+	set(value):
+		dirty = value
+		if value == true:
+			dirtied.emit()
+
 var loaded := false
 
 var filepath: String

--- a/lorien/ProjectManager/ProjectManager.gd
+++ b/lorien/ProjectManager/ProjectManager.gd
@@ -1,8 +1,17 @@
 extends Node
 
 # -------------------------------------------------------------------------------------------------
+signal active_project_changed(previous_project: Project, current_project: Project)
+
 var _open_projects: Array[Project]
-var _active_project: Project
+
+var _active_project: Project:
+	set(value):
+		if _active_project == value:
+			return
+		var previous_project: Project = _active_project
+		_active_project = value
+		active_project_changed.emit(previous_project, _active_project)
 
 # -------------------------------------------------------------------------------------------------
 func read_project_list() -> void:

--- a/lorien/UI/Components/FlatTextureButton.gd
+++ b/lorien/UI/Components/FlatTextureButton.gd
@@ -4,6 +4,7 @@ extends TextureButton
 # -------------------------------------------------------------------------------------------------
 @export var hover_tint := Color.WHITE
 @export var pressed_tint := Color.WHITE
+@export var disabled_tint := Color(0.4, 0.4, 0.4)
 var _normal_tint: Color
 
 # -------------------------------------------------------------------------------------------------
@@ -11,39 +12,43 @@ func _ready() -> void:
 	_normal_tint = self_modulate
 	mouse_entered.connect(_on_mouse_entered)
 	mouse_exited.connect(_on_mouse_exited)
-	pressed.connect(_on_pressed)
-
-	if toggle_mode && button_pressed:
-		self_modulate = pressed_tint
+	toggled.connect(_on_toggled)
+	_update_tint()
 
 # -------------------------------------------------------------------------------------------------
 func _exit_tree() -> void:
 	mouse_entered.disconnect(_on_mouse_entered)
 	mouse_exited.disconnect(_on_mouse_exited)
-	pressed.disconnect(_on_pressed)
+	toggled.disconnect(_on_toggled)
 
 # -------------------------------------------------------------------------------------------------
 func _on_mouse_entered() -> void:
-	if !button_pressed:
-		self_modulate = hover_tint
+	call_deferred("_update_tint")
 
 # -------------------------------------------------------------------------------------------------
 func _on_mouse_exited() -> void:
-	if !button_pressed:
-		self_modulate = _normal_tint
+	call_deferred("_update_tint")
 
 # -------------------------------------------------------------------------------------------------
 func toggle() -> void:
-	if button_pressed:
-		self_modulate = _normal_tint
-	else:
-		self_modulate = pressed_tint
 	button_pressed = !button_pressed
 
 # -------------------------------------------------------------------------------------------------
-func _on_pressed() -> void:
-	if toggle_mode:
-		if button_pressed:
-			self_modulate = pressed_tint
-		else:
-			self_modulate = _normal_tint
+func _on_toggled(_toggled_on: bool) -> void:
+	_update_tint()
+
+# -------------------------------------------------------------------------------------------------
+func set_is_disabled(value: bool) -> void:
+	disabled = value
+	_update_tint()
+
+# -------------------------------------------------------------------------------------------------
+func _update_tint() -> void:
+	if disabled:
+		self_modulate = disabled_tint
+	elif button_pressed:
+		self_modulate = pressed_tint
+	elif is_hovered():
+		self_modulate = hover_tint
+	else:
+		self_modulate = _normal_tint

--- a/lorien/UI/Toolbar.gd
+++ b/lorien/UI/Toolbar.gd
@@ -56,6 +56,7 @@ func _ready():
 	_tool_btn_line.pressed.connect(_on_LineToolButton_pressed)
 	_tool_btn_eraser.pressed.connect(_on_EraserToolButton_pressed)
 	_tool_btn_selection.pressed.connect(_on_SelectToolButton_pressed)
+	ProjectManager.active_project_changed.connect(_on_active_project_changed)
 	
 # Button clicked callbacks
 # -------------------------------------------------------------------------------------------------

--- a/lorien/UI/Toolbar.gd
+++ b/lorien/UI/Toolbar.gd
@@ -165,3 +165,34 @@ func _change_active_tool_button(btn: TextureButton) -> void:
 # -------------------------------------------------------------------------------------------------
 func get_brush_color_button() -> Control:
 	return _color_button
+
+# -------------------------------------------------------------------------------------------------
+func _on_active_project_changed(previous_project: Project, current_project: Project) -> void:
+	_update_undo_redo_buttons()
+	
+	if previous_project != null:
+		previous_project.dirtied.disconnect(_on_project_dirtied)
+		previous_project.undo_redo.version_changed.disconnect(_on_undo_or_redo_occured)
+	
+	if current_project != null:
+		current_project.dirtied.connect(_on_project_dirtied)
+		current_project.undo_redo.version_changed.connect(_on_undo_or_redo_occured)
+
+# -------------------------------------------------------------------------------------------------
+func _on_project_dirtied() -> void:
+	_update_undo_redo_buttons()
+
+# -------------------------------------------------------------------------------------------------
+func _on_undo_or_redo_occured() -> void:
+	_update_undo_redo_buttons()
+
+# -------------------------------------------------------------------------------------------------
+func _update_undo_redo_buttons() -> void:
+	var active_project: Project = ProjectManager.get_active_project()
+	if active_project == null:
+		_undo_button.set_is_disabled(true)
+		_redo_button.set_is_disabled(true)
+		return
+	
+	_undo_button.set_is_disabled(!active_project.undo_redo.has_undo())
+	_redo_button.set_is_disabled(!active_project.undo_redo.has_redo())


### PR DESCRIPTION
Second take. (First take: #256)
I've rewritten it from scratch for the new Godot 4 version. I think my new approach looks much cleaner; let me know if anything needs to be changed.

I've tested it and it works as expected when switching between tabs, adding tabs, closing tabs, and loading projects. And this time the undo/redo buttons don't react when you zoom in/out, although, zooming still incorrectly dirties the project as mentioned in my previous PR.