### PR TITLE
Disable stroke while panning or zooming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Mono-specific ignores
 .mono/
 data_*/
+
+# Visual Studio Code-specific ignores
+.vscode/

--- a/lorien/InfiniteCanvas/InfiniteCanvas.gd
+++ b/lorien/InfiniteCanvas/InfiniteCanvas.gd
@@ -55,6 +55,11 @@ func _ready() -> void:
 			_camera.zoom_changed.connect(Callable(child, "_on_zoom_changed"))
 			_camera.position_changed.connect(Callable(child, "_on_canvas_position_changed"))
 	
+	for child in get_children():
+		if child is CanvasTool:
+			_camera.is_panning.connect(Callable(child, "_on_is_panning"))
+			_camera.is_zooming.connect(Callable(child, "_on_is_zooming"))
+	
 	_camera.zoom_changed.connect(_on_zoom_changed)
 	_camera.position_changed.connect(_on_camera_moved)
 	#_viewport.size = get_window().size

--- a/lorien/InfiniteCanvas/InfiniteCanvas.gd
+++ b/lorien/InfiniteCanvas/InfiniteCanvas.gd
@@ -52,13 +52,13 @@ func _ready() -> void:
 	
 	for child in $SubViewport.get_children():
 		if child is BaseCursor:
-			_camera.zoom_changed.connect(Callable(child, "_on_zoom_changed"))
-			_camera.position_changed.connect(Callable(child, "_on_canvas_position_changed"))
+			_camera.zoom_changed.connect(child._on_zoom_changed)
+			_camera.position_changed.connect(child._on_canvas_position_changed)
 	
 	for child in get_children():
 		if child is CanvasTool:
-			_camera.is_panning.connect(Callable(child, "_on_is_panning"))
-			_camera.is_zooming.connect(Callable(child, "_on_is_zooming"))
+			_camera.panning_toggled.connect(child._on_panning_toggled)
+			_camera.zooming_toggled.connect(child._on_zooming_toggled)
 	
 	_camera.zoom_changed.connect(_on_zoom_changed)
 	_camera.position_changed.connect(_on_camera_moved)

--- a/lorien/InfiniteCanvas/PanZoomCamera.gd
+++ b/lorien/InfiniteCanvas/PanZoomCamera.gd
@@ -1,7 +1,9 @@
 extends Camera2D
 
 # -------------------------------------------------------------------------------------------------
+signal is_zooming(value: bool)
 signal zoom_changed(value: float)
+signal is_panning(value: bool)
 signal position_changed(value: Vector2)
 
 # -------------------------------------------------------------------------------------------------
@@ -39,8 +41,10 @@ func tool_event(event: InputEvent) -> void:
 		if event is InputEventKey:
 			if Utils.is_action_pressed("canvas_pan_key", event):
 				_pan_active = true
+				is_panning.emit(true)
 			if Utils.is_action_released("canvas_pan_key", event):
 				_pan_active = false
+				is_panning.emit(false)
 		if event is InputEventMouseButton:
 			
 			# Scroll wheel up/down to zoom
@@ -55,10 +59,14 @@ func tool_event(event: InputEvent) -> void:
 			if event.button_index == MOUSE_BUTTON_MIDDLE:
 				if !event.ctrl_pressed:
 					_pan_active = event.is_pressed()
+					is_panning.emit(_pan_active)
 					_zoom_active = false
+					is_zooming.emit(false)
 				else:
 					_zoom_active = event.is_pressed()
+					is_zooming.emit(_zoom_active)
 					_pan_active = false
+					is_panning.emit(false)
 					_start_mouse_pos = get_local_mouse_position()
 					
 		elif event is InputEventMouseMotion:

--- a/lorien/InfiniteCanvas/PanZoomCamera.gd
+++ b/lorien/InfiniteCanvas/PanZoomCamera.gd
@@ -1,9 +1,9 @@
 extends Camera2D
 
 # -------------------------------------------------------------------------------------------------
-signal is_zooming(value: bool)
+signal zooming_toggled(value: bool)
 signal zoom_changed(value: float)
-signal is_panning(value: bool)
+signal panning_toggled(value: bool)
 signal position_changed(value: Vector2)
 
 # -------------------------------------------------------------------------------------------------
@@ -41,10 +41,10 @@ func tool_event(event: InputEvent) -> void:
 		if event is InputEventKey:
 			if Utils.is_action_pressed("canvas_pan_key", event):
 				_pan_active = true
-				is_panning.emit(true)
+				panning_toggled.emit(true)
 			if Utils.is_action_released("canvas_pan_key", event):
 				_pan_active = false
-				is_panning.emit(false)
+				panning_toggled.emit(false)
 		if event is InputEventMouseButton:
 			
 			# Scroll wheel up/down to zoom
@@ -59,14 +59,14 @@ func tool_event(event: InputEvent) -> void:
 			if event.button_index == MOUSE_BUTTON_MIDDLE:
 				if !event.ctrl_pressed:
 					_pan_active = event.is_pressed()
-					is_panning.emit(_pan_active)
+					panning_toggled.emit(_pan_active)
 					_zoom_active = false
-					is_zooming.emit(false)
+					zooming_toggled.emit(false)
 				else:
 					_zoom_active = event.is_pressed()
-					is_zooming.emit(_zoom_active)
+					zooming_toggled.emit(_zoom_active)
 					_pan_active = false
-					is_panning.emit(false)
+					panning_toggled.emit(false)
 					_start_mouse_pos = get_local_mouse_position()
 					
 		elif event is InputEventMouseMotion:

--- a/lorien/InfiniteCanvas/Tools/BrushTool.gd
+++ b/lorien/InfiniteCanvas/Tools/BrushTool.gd
@@ -22,8 +22,10 @@ func tool_event(event: InputEvent) -> void:
 		_current_pressure = event.pressure
 		if performing_stroke:
 			_cursor.set_pressure(event.pressure)
+		if zooming_detected && performing_stroke:
+			end_stroke()
 
-	elif event is InputEventMouseButton:
+	elif event is InputEventMouseButton && !disable_stroke:
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			if event.pressed:
 				start_stroke()

--- a/lorien/InfiniteCanvas/Tools/CanvasTool.gd
+++ b/lorien/InfiniteCanvas/Tools/CanvasTool.gd
@@ -36,14 +36,14 @@ func _on_brush_size_changed(size: int) -> void:
 	_cursor.change_size(size)
 
 # -------------------------------------------------------------------------------------------------
-func _on_is_panning(is_panning: bool) -> void:
-	panning_detected = is_panning
-	eval_disable_stroke()
+func _on_panning_toggled(panning_enabled: bool) -> void:
+	panning_detected = panning_enabled
+	_eval_disable_stroke()
 
 # -------------------------------------------------------------------------------------------------
-func _on_is_zooming(is_zooming: bool) -> void:
-	zooming_detected = is_zooming
-	eval_disable_stroke()
+func _on_zooming_toggled(zooming_enabled: bool) -> void:
+	zooming_detected = zooming_enabled
+	_eval_disable_stroke()
 
 # -------------------------------------------------------------------------------------------------
 func get_cursor() -> BaseCursor:
@@ -102,7 +102,7 @@ func end_stroke() -> void:
 	_canvas.end_stroke()
 	performing_stroke = false
 
-func eval_disable_stroke() -> void:
+func _eval_disable_stroke() -> void:
 	disable_stroke = panning_detected || zooming_detected
 
 # TODO(gd4): probably don't need this anymore

--- a/lorien/InfiniteCanvas/Tools/CanvasTool.gd
+++ b/lorien/InfiniteCanvas/Tools/CanvasTool.gd
@@ -13,6 +13,9 @@ var _cursor: BaseCursor
 var _canvas: InfiniteCanvas
 var enabled := false: get = get_enabled, set = set_enabled
 var performing_stroke := false
+var disable_stroke := false
+var panning_detected := false
+var zooming_detected := false
 
 # -------------------------------------------------------------------------------------------------
 func _ready() -> void:
@@ -31,6 +34,16 @@ func _on_brush_color_changed(color: Color) -> void:
 # -------------------------------------------------------------------------------------------------
 func _on_brush_size_changed(size: int) -> void:
 	_cursor.change_size(size)
+
+# -------------------------------------------------------------------------------------------------
+func _on_is_panning(is_panning: bool) -> void:
+	panning_detected = is_panning
+	eval_disable_stroke()
+
+# -------------------------------------------------------------------------------------------------
+func _on_is_zooming(is_zooming: bool) -> void:
+	zooming_detected = is_zooming
+	eval_disable_stroke()
 
 # -------------------------------------------------------------------------------------------------
 func get_cursor() -> BaseCursor:
@@ -88,6 +101,9 @@ func get_current_brush_stroke() -> BrushStroke:
 func end_stroke() -> void:
 	_canvas.end_stroke()
 	performing_stroke = false
+
+func eval_disable_stroke() -> void:
+	disable_stroke = panning_detected || zooming_detected
 
 # TODO(gd4): probably don't need this anymore
 # -------------------------------------------------------------------------------------------------

--- a/lorien/InfiniteCanvas/Tools/CircleTool.gd
+++ b/lorien/InfiniteCanvas/Tools/CircleTool.gd
@@ -35,7 +35,7 @@ func tool_event(event: InputEvent) -> void:
 			_make_ellipse(PRESSURE, STEP_IN_MOTION, should_draw_circle)
 		
 	# Start + End
-	elif event is InputEventMouseButton:
+	elif event is InputEventMouseButton && !disable_stroke:
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			if event.pressed:
 				start_stroke()

--- a/lorien/InfiniteCanvas/Tools/EraserTool.gd
+++ b/lorien/InfiniteCanvas/Tools/EraserTool.gd
@@ -14,7 +14,7 @@ var _bounding_box_cache := {} # BrushStroke -> Rect2
 func tool_event(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		_last_mouse_position = _cursor.global_position
-	if event is InputEventMouseButton:
+	if event is InputEventMouseButton && !disable_stroke:
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			if event.pressed:
 				if _bounding_box_cache.is_empty():

--- a/lorien/InfiniteCanvas/Tools/LineTool.gd
+++ b/lorien/InfiniteCanvas/Tools/LineTool.gd
@@ -30,7 +30,7 @@ func tool_event(event: InputEvent) -> void:
 				_tail = _add_point_at_mouse_pos(0.5)
 	
 	# Start + End
-	elif event is InputEventMouseButton:
+	elif event is InputEventMouseButton && !disable_stroke:
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			if event.pressed:
 				start_stroke()

--- a/lorien/InfiniteCanvas/Tools/RectangleTool.gd
+++ b/lorien/InfiniteCanvas/Tools/RectangleTool.gd
@@ -19,7 +19,7 @@ func tool_event(event: InputEvent) -> void:
 			_make_rectangle(PRESSURE)
 		
 	# Start + End
-	elif event is InputEventMouseButton:
+	elif event is InputEventMouseButton && !disable_stroke:
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			if event.pressed:
 				start_stroke()

--- a/lorien/InfiniteCanvas/Tools/SelectionTool.gd
+++ b/lorien/InfiniteCanvas/Tools/SelectionTool.gd
@@ -57,7 +57,7 @@ func tool_event(event: InputEvent) -> void:
 			_cursor.mode = SelectionCursor.Mode.MOVE
 			_paste_strokes(strokes)
 
-	if event is InputEventMouseButton:
+	if event is InputEventMouseButton && !disable_stroke:
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			# LMB down - decide if we should select/multiselect or move the selection
 			if event.pressed:


### PR DESCRIPTION
Closes #301 .

Branched off main. Tested in debug and Windows release export.

**Notable changes and explanation of new behaviour:**
- While panning or zooming drawing will no longer be possible.
- The brush tool has a special behaviour: when starting to draw with the brush, then starting to zoom, the brush stroke is ended.
- No matter the tool, if you start drawing and then pan while drawing, you can continue drawing smoothly from where you left off once you stop panning.
- Except for the brush tool, geometric shapes can be adjusted while zooming after they have been initiated.

**Observed bugs:**
- For some reason my graphic tablet's pen movement is not recognized. That seems to be an issue with the main branch though and was not introduced by me.
- Sometimes, while drawing, panning and or zooming, the cursor might disappear / become invisible. It will reappear upon drawing somewhere again. I was not able to reproduce this issue reliably though.