### PR TITLE
Fixed selection cursor zoom

### DIFF
--- a/lorien/InfiniteCanvas/Cursor/SelectionCursor/SelectionCursor.gd
+++ b/lorien/InfiniteCanvas/Cursor/SelectionCursor/SelectionCursor.gd
@@ -15,7 +15,7 @@ var mode := Mode.SELECT: get = get_mode, set = set_mode
 
 # -------------------------------------------------------------------------------------------------
 func _on_zoom_changed(zoom_value: float) -> void:
-	scale = Vector2.ONE * zoom_value
+	scale = Vector2.ONE / zoom_value
 
 # -------------------------------------------------------------------------------------------------
 func set_mode(m: Mode) -> void:


### PR DESCRIPTION
Small fix where the selection cursor was scaling wrong causing the cursor to be invisible at small zoom and be too large on high zoom