### PR TITLE
Popup shortcuts

### DIFF
--- a/lorien/UI/Dialogs/AlertDialog.gd
+++ b/lorien/UI/Dialogs/AlertDialog.gd
@@ -3,3 +3,8 @@ extends AcceptDialog
 # ------------------------------------------------------------------------------------------------
 func _ready() -> void:
 	close_requested.connect(hide)
+# ------------------------------------------------------------------------------------------------
+func _input(event: InputEvent) -> void:
+	if event is InputEventKey:
+		if event.keycode==KEY_ESCAPE:
+			hide()

--- a/lorien/UI/Dialogs/DeletePaletteDialog.gd
+++ b/lorien/UI/Dialogs/DeletePaletteDialog.gd
@@ -33,3 +33,11 @@ func _on_delete_pressed() -> void:
 # -------------------------------------------------------------------------------------------------
 func _on_cancel_pressed() -> void:
 	get_parent().hide()
+
+# -------------------------------------------------------------------------------------------------
+func _input(event):
+	if event is InputEventKey:
+		if event.keycode==KEY_D:
+			_on_delete_pressed()
+		elif event.keycode==KEY_C || event.keycode==KEY_ESCAPE:
+			_on_cancel_pressed()

--- a/lorien/UI/Dialogs/EditPaletteDialog.gd
+++ b/lorien/UI/Dialogs/EditPaletteDialog.gd
@@ -127,3 +127,8 @@ func _on_RemoveColorButton_pressed() -> void:
 		_active_button_index = min(_active_button_index, _color_grid.get_child_count() - 1)
 		_active_button = _color_grid.get_child(_active_button_index)
 		_on_platte_button_pressed(_active_button, _color_grid.get_child_count() - 1)
+# ------------------------------------------------------------------------------------------------
+func _input(event: InputEvent) -> void:
+	if event is InputEventKey:
+		if event.keycode==KEY_ESCAPE:
+			_on_EditPaletteDialog_close_requested()

--- a/lorien/UI/Dialogs/NewPaletteDialog.gd
+++ b/lorien/UI/Dialogs/NewPaletteDialog.gd
@@ -54,3 +54,15 @@ func _on_about_to_popup() -> void:
 		get_parent().title = tr("NEW_PALETTE_DIALOG_CREATE_TITLE")
 	
 	# TODO: Grab focus
+
+# -------------------------------------------------------------------------------------------------
+func cancel()->void:
+	get_parent().hide()
+# -------------------------------------------------------------------------------------------------
+func _input(event):
+	if event is InputEventKey:
+		if event.keycode==KEY_ENTER:
+			_on_SaveButton_pressed()
+		elif event.keycode==KEY_ESCAPE:
+			cancel()
+

--- a/lorien/UI/Dialogs/UnsavedChangesDialog.gd
+++ b/lorien/UI/Dialogs/UnsavedChangesDialog.gd
@@ -12,16 +12,24 @@ signal discard_changes
 func _ready() -> void:
 	get_parent().close_requested.connect(get_parent().hide)
 	
-	_save_button.pressed.connect(func() -> void:
-		get_parent().hide()
-		save_changes.emit()
-	)
+	_save_button.pressed.connect(save)
 	
-	_discard_button.pressed.connect(func() -> void: 
-		get_parent().hide()
-		discard_changes.emit()
-	)
+	_discard_button.pressed.connect(discard)
+#-------------------------------------
+func save() ->void:
+	get_parent().hide()
+	save_changes.emit()
 
+func discard()->void:
+	get_parent().hide()
+	discard_changes.emit()
 # -------------------------------------------------------------------------------------------------
 func set_text(text: String) -> void:
 	$Label.text = text
+
+func _input(event):
+	if event is InputEventKey:
+		if event.keycode==KEY_S:
+			save()
+		elif event.keycode==KEY_D:
+			discard()

--- a/lorien/UI/Dialogs/UnsavedChangesDialog.gd
+++ b/lorien/UI/Dialogs/UnsavedChangesDialog.gd
@@ -26,10 +26,15 @@ func discard()->void:
 # -------------------------------------------------------------------------------------------------
 func set_text(text: String) -> void:
 	$Label.text = text
-
-func _input(event):
+# -------------------------------------------------------------------------------------------------
+func cancel()->void:
+	get_parent().hide()
+# -------------------------------------------------------------------------------------------------
+func _input(event:InputEvent)->void:
 	if event is InputEventKey:
 		if event.keycode==KEY_S:
 			save()
 		elif event.keycode==KEY_D:
 			discard()
+		elif event.keycode==KEY_ESCAPE:
+			cancel()


### PR DESCRIPTION
# Added keyboard shortcuts to popups and alerts (S for save, D for discard, Escape to cancel)

when a **popup** like (**save** **discard**) appear the **user** can simply press (**s**) for **save** , (**d**) for **discard** or (**escape**) to **cancel** and **hide** popup withoute the need to use the mouse

**like blender's alert's system**

_much faster_