### PR TITLE
Static grid option / function

### DIFF
--- a/lorien/Assets/I18n/en.txt
+++ b/lorien/Assets/I18n/en.txt
@@ -74,6 +74,7 @@ SETTINGS_UI_SCALE               UI Scale
 SETTINGS_UI_SCALE_AUTO          Auto
 SETTINGS_UI_SCALE_CUSTOM        Custom
 SETTINGS_GRID_SIZE              Grid Size
+SETTINGS_STATIC_GRID            Static Grid
 SETTINGS_GRID_PATTERN           Grid Pattern
 SETTINGS_CANVAS_COLOR           Canvas Color
 SETTINGS_FPS_FOREGROUND         Foreground Fps

--- a/lorien/Config.gd
+++ b/lorien/Config.gd
@@ -26,4 +26,5 @@ const DEFAULT_BRUSH_ROUNDING		:= Types.BrushRoundingType.ROUNDED
 const DEFAULT_UI_SCALE_MODE 		:= Types.UIScale.AUTO
 const DEFAULT_UI_SCALE  			:= 1.0
 const DEFAULT_GRID_PATTERN 			:= Types.GridPattern.DOTS
+const DEFAULT_STATIC_GRID			:= false
 const DEFAULT_GRID_SIZE 			:= 25.0

--- a/lorien/InfiniteCanvas/InfiniteCanvasGrid.gd
+++ b/lorien/InfiniteCanvas/InfiniteCanvasGrid.gd
@@ -8,10 +8,14 @@ var _pattern: int = Types.GridPattern.DOTS
 var _camera: Camera2D
 var _grid_size := Config.DEFAULT_GRID_SIZE
 var _grid_color: Color
+var _static_grid := Config.DEFAULT_STATIC_GRID
+var _line_size: float = ceil(Config.DEFAULT_GRID_SIZE / 10.0)
 
 # -------------------------------------------------------------------------------------------------
 func _ready() -> void:
 	_grid_size = Settings.get_value(Settings.APPEARANCE_GRID_SIZE, Config.DEFAULT_GRID_SIZE)
+	_line_size = ceil(_grid_size / 10.0)
+	_static_grid = Settings.get_value(Settings.APPEARANCE_STATIC_GRID, Config.DEFAULT_STATIC_GRID)
 	_pattern = Settings.get_value(Settings.APPEARANCE_GRID_PATTERN, Config.DEFAULT_GRID_PATTERN)
 	
 	_camera = get_node(camera_path)
@@ -32,6 +36,12 @@ func _on_viewport_size_changed() -> void: queue_redraw()
 # -------------------------------------------------------------------------------------------------
 func set_grid_size(size: int) -> void:
 	_grid_size = size
+	_line_size = ceil(size/10.0)
+	queue_redraw()
+	
+# -------------------------------------------------------------------------------------------------
+func set_static_grid(static_grid: bool) -> void:
+	_static_grid = static_grid
 	queue_redraw()
 
 # -------------------------------------------------------------------------------------------------
@@ -49,8 +59,8 @@ func _draw() -> void:
 	var zoom := (Vector2.ONE / _camera.zoom).x
 	var size := Vector2(get_viewport().size.x, get_viewport().size.y) * zoom
 	var offset := _camera.offset
-	var grid_size := int(ceil((_grid_size * pow(zoom, 0.75))))
-		
+	var grid_size := int(_grid_size) if _static_grid else int(ceil(_grid_size * pow(zoom, 0.75)))
+	
 	match _pattern:
 		Types.GridPattern.DOTS:
 			var dot_size := int(ceil(grid_size * 0.12))
@@ -64,14 +74,15 @@ func _draw() -> void:
 					var pos := Vector2(x, y) * grid_size
 					draw_rect(Rect2(pos.x, pos.y, dot_size, dot_size), _grid_color)
 		Types.GridPattern.LINES:
+			var line_size = _line_size if _static_grid else -1
 			# Vertical lines
 			var start_index := int(offset.x / grid_size) - 1
 			var end_index := int((size.x + offset.x) / grid_size) + 1
 			for i in range(start_index, end_index):
-				draw_line(Vector2(i * grid_size, offset.y + size.y), Vector2(i * grid_size, offset.y - size.y), _grid_color)
+				draw_line(Vector2(i * grid_size, offset.y + size.y), Vector2(i * grid_size, offset.y - size.y), _grid_color, line_size)
 
 			# Horizontal lines
 			start_index = int(offset.y / grid_size) - 1
 			end_index = int((size.y + offset.y) / grid_size) + 1
 			for i in range(start_index, end_index):
-				draw_line(Vector2(offset.x + size.x, i * grid_size), Vector2(offset.x - size.x, i * grid_size), _grid_color)
+				draw_line(Vector2(offset.x + size.x, i * grid_size), Vector2(offset.x - size.x, i * grid_size), _grid_color, line_size)

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -87,6 +87,7 @@ func _ready() -> void:
 	
 	_settings_dialog.ui_scale_changed.connect(_on_scale_changed)
 	_settings_dialog.grid_size_changed.connect(_on_grid_size_changed)
+	_settings_dialog.static_grid_changed.connect(_on_static_grid_changed)
 	_settings_dialog.grid_pattern_changed.connect(_on_grid_pattern_changed)
 	_settings_dialog.canvas_color_changed.connect(_on_canvas_color_changed)
 	_settings_dialog.constant_pressure_changed.connect(_on_constant_pressure_changed)
@@ -358,6 +359,10 @@ func _on_brush_size_changed(brush_size: int) -> void:
 # -------------------------------------------------------------------------------------------------
 func _on_grid_size_changed(grid_size: int) -> void:
 	_canvas_grid.set_grid_size(grid_size)
+
+# -------------------------------------------------------------------------------------------------
+func _on_static_grid_changed(static_grid: bool) -> void:
+	_canvas_grid.set_static_grid(static_grid)
 
 # -------------------------------------------------------------------------------------------------
 func _on_grid_pattern_changed(pattern: int) -> void:

--- a/lorien/Misc/Settings.gd
+++ b/lorien/Misc/Settings.gd
@@ -20,6 +20,7 @@ const APPEARANCE_THEME 					:= "appearance_theme"
 const APPEARANCE_UI_SCALE_MODE  		:= "appearance_ui_scale_mode"
 const APPEARANCE_UI_SCALE				:= "appearance_ui_scale"
 const APPEARANCE_GRID_PATTERN			:= "appearance_grid_pattern"
+const APPEARANCE_STATIC_GRID			:= "appearance_static_grid"
 const APPEARANCE_GRID_SIZE				:= "appearance_grid_size"
 const APPEARANCE_CANVAS_COLOR 			:= "appearance_canvas_color"
 

--- a/lorien/UI/Dialogs/SettingsDialog.gd
+++ b/lorien/UI/Dialogs/SettingsDialog.gd
@@ -22,6 +22,7 @@ const BRUSH_STROKE_CAP_ROUND 	:= 1
 signal ui_scale_changed
 signal canvas_color_changed(color: Color)
 signal grid_size_changed(size: int)
+signal static_grid_changed(static_grid: bool)
 signal grid_pattern_changed(pattern: Types.GridPattern)
 signal constant_pressure_changed(state: bool)
 
@@ -48,6 +49,7 @@ signal constant_pressure_changed(state: bool)
 @onready var _ui_scale_mode: OptionButton = %UIScaleOptions
 @onready var _ui_scale: SpinBox = %UIScale
 @onready var _grid_size: SpinBox = %GridSize
+@onready var _static_grid: CheckBox = %StaticGrid
 @onready var _grid_pattern: OptionButton = %GridPattern
 @onready var _foreground_fps: SpinBox = %ForgroundFramerate
 @onready var _background_fps: SpinBox = %BackgroundFramerate
@@ -74,6 +76,7 @@ func _ready() -> void:
 	_ui_scale.value_changed.connect(_on_ui_scale_changed)
 	_canvas_color.color_changed.connect(_on_canvas_color_changed)
 	_grid_pattern.item_selected.connect(_on_grid_pattern_selected)
+	_static_grid.toggled.connect(_on_static_grid_toggled)
 	_grid_size.value_changed.connect(_on_grid_size_changed)
 	_brush_rounding.item_selected.connect(_on_brush_rounding_selected)
 	_foreground_fps.value_changed.connect(_on_foreground_fps_changed)
@@ -100,6 +103,7 @@ func _set_values() -> void:
 	var ui_scale: float = Settings.get_value(Settings.APPEARANCE_UI_SCALE, Config.DEFAULT_UI_SCALE)
 	var ui_scale_mode: Types.UIScale = Settings.get_value(Settings.APPEARANCE_UI_SCALE_MODE, Config.DEFAULT_UI_SCALE_MODE)
 	var grid_pattern: Types.GridPattern = Settings.get_value(Settings.APPEARANCE_GRID_PATTERN, Config.DEFAULT_GRID_PATTERN)
+	var static_grid: bool = Settings.get_value(Settings.APPEARANCE_STATIC_GRID, Config.DEFAULT_STATIC_GRID)
 	var grid_size: int = Settings.get_value(Settings.APPEARANCE_GRID_SIZE, Config.DEFAULT_GRID_SIZE)
 	
 	var foreground_fps: int = Settings.get_value(Settings.RENDERING_FOREGROUND_FPS, Config.DEFAULT_FOREGROUND_FPS)
@@ -129,6 +133,7 @@ func _set_values() -> void:
 	_tool_pressure.value = tool_pressure
 	_canvas_color.color = canvas_color
 	_grid_size.value = grid_size
+	_static_grid.button_pressed = static_grid
 	match grid_pattern:
 		Types.GridPattern.DOTS: _grid_pattern.selected = GRID_PATTERN_DOTS_INDEX
 		Types.GridPattern.LINES: _grid_pattern.selected = GRID_PATTERN_LINES_INDEX
@@ -230,6 +235,11 @@ func _on_grid_size_changed(value: int) -> void:
 	Settings.set_value(Settings.APPEARANCE_GRID_SIZE, value)
 	grid_size_changed.emit(value)
 	
+# -------------------------------------------------------------------------------------------------
+func _on_static_grid_toggled(button_pressed: bool) -> void:
+	Settings.set_value(Settings.APPEARANCE_STATIC_GRID, button_pressed)
+	static_grid_changed.emit(button_pressed)
+
 # -------------------------------------------------------------------------------------------------
 func _on_grid_pattern_selected(index: int) -> void:
 	var pattern: int = Types.GridPattern.NONE

--- a/lorien/UI/Dialogs/SettingsDialog.tscn
+++ b/lorien/UI/Dialogs/SettingsDialog.tscn
@@ -302,6 +302,21 @@ popup/item_1/id = 1
 popup/item_2/text = "None"
 popup/item_2/id = 2
 
+[node name="StaticGrid" type="HBoxContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/AppearanceContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="VBoxContainer/MarginContainer/VBoxContainer/AppearanceContainer/VBoxContainer/StaticGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 6
+text = "SETTINGS_STATIC_GRID"
+
+[node name="StaticGrid" type="CheckBox" parent="VBoxContainer/MarginContainer/VBoxContainer/AppearanceContainer/VBoxContainer/StaticGrid"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
 [node name="GridSize" type="HBoxContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/AppearanceContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3


### PR DESCRIPTION
In response to the issues #310 and #257 (and my own frustration of the grid size always changing).

I added a static grid option in the appearance settings that makes the grid static such that zoom-in/out does not change the grid and notes stay in the same place relative to the grid. I mostly use Lorien for taking math notes / making exercises so having a static grid helps a lot with keeping everything ordered, though I added it as an option in the settings such that others can still use it as they are used to.

To keep the line visible I currently added a line_size as the `(grid_size / 10.0)`, tho this could also be changed to a setting if deemed necessary. (Although the grid lines being only 1 pixel thick in general makes the lines hard to see)

I have been able to solve most issues I have except for 2
- Translations of "Static Grid" into all the diverse languages used
- Checkbox color being off after opening settings with static grid turned on

Both the static grid and the checkbox not being colored properly are shown in the video below.

https://github.com/user-attachments/assets/cf6f2ffc-d8c6-4a05-8e02-ede4fb348504


