### PR TITLE
Save as Dialog for unsaved projects that were changed during exiting the application.

### DIFF
--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -466,7 +466,6 @@ func _on_tool_changed(tool_type: int) -> void:
 # -------------------------------------------------------------------------------------------------
 func _on_save_unsaved_changes() -> void:
 	if _exit_requested:
-#		ProjectManager.save_all_projects()
 		for project in ProjectManager.get_open_projects():
 			ProjectManager.make_project_active(project)
 			if project.filepath.is_empty() && project.loaded && project.dirty:


### PR DESCRIPTION
As described in #341 before if you add a line in a not yet saved file and you exited the application, and clicked saved the unsaved changes, the project was discarded. With this change for every unsaved project that has some kind of change in it, a save as file dialog will show up and gives you the possibility to save the projects before exiting the application.